### PR TITLE
Refactor contact force format

### DIFF
--- a/flygym/util/config.py
+++ b/flygym/util/config.py
@@ -27,6 +27,7 @@ all_tarsi_collisions_geoms = [
     for pos in "FMH"
     for dof in ["Tarsus1", "Tarsus2", "Tarsus3", "Tarsus4", "Tarsus5"]
 ]
+all_tarsi_links = ["Tarsus1", "Tarsus2", "Tarsus3", "Tarsus4", "Tarsus5"]
 
 all_legs_collisions_geoms = [
     f"{side}{pos}{dof}_collision"


### PR DESCRIPTION
Refactor the format of the list that specifies which contact sensors should be placed: supply the list of link names without specifying which leg (eg. "Tarsus1" instead of "FRTarsus1"). This list is repeated 6 times by `NeuroMechFlyMuJoCo`.

This further allows the reading to be reshaped into an array of shape (6, num_geoms) instead of (6 * num_geoms,), which I think is more user friendly.

Finally the readings are return as a copy, so it's immutable across the simulation loop (closes #21).