### PR TITLE
Fix doc website: add optional dependency for tutorials

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,6 +15,7 @@ jobs:
           #pip install sphinx sphinx_rtd_theme furo numpydoc
           pip install -e ."[mujoco]"
           pip install -e ."[dev]"
+          pip install -e ."[tutorials]"
       - name: Sphinx build
         run: |
           sphinx-build doc/source _build

--- a/doc/source/tutorials/rule_based_controller.rst
+++ b/doc/source/tutorials/rule_based_controller.rst
@@ -5,6 +5,15 @@ Rule-based controller
 achieved through local coordination rules in absence of a centralized
 mechanism like the CPG.
 
+.. note:: 
+    Additional dependencies are required to follow this tutorial. In
+    addition to the standard installation, please also run:
+    
+    .. code:: bash
+
+       pip install -e "flygym[tutorials]"
+    
+
 Previously, we have covered how a centralized network of oscillators
 (CPGs) can give rise to locomotion. An more decentralized mechanism for
 insect locomotion has been proposed as an alternative: locomotion can

--- a/flygym/mujoco/core.py
+++ b/flygym/mujoco/core.py
@@ -1746,8 +1746,14 @@ class NeuroMechFly(gym.Env):
         """
         if self.render_mode != "saved":
             logging.warning(
-                'Render mode is not "saved"; no video will be '
-                "saved despite `save_video()` call."
+                'Render mode is not "saved"; no video will be saved despite '
+                "`save_video()` call."
+            )
+        elif len(self._frames) == 0:
+            logging.warning(
+                "No frames have been rendered yet; no video will be saved despite "
+                "`save_video()` call. Be sure to call `.render()` in your simulation "
+                "loop."
             )
 
         num_stab_frames = int(np.ceil(stabilization_time / self._eff_render_interval))

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             "rasterio",
             "requests",
         ],
+        "tutorials": ["networkx"],
     },
     url="https://neuromechfly.org/",
     long_description=open("README.md").read(),


### PR DESCRIPTION
### Description
Add `flygym[tutorials]` optional dependency so tutorials can build correctly.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [x] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
NA