### PR TITLE
Support MuJoCo 3.x.x

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/flygym/data/mjcf/groundwalking_nmf_mjcf_nofloor_230518__bendTarsus_scaled.xml
+++ b/flygym/data/mjcf/groundwalking_nmf_mjcf_nofloor_230518__bendTarsus_scaled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <mujoco model="Animat">
   <compiler autolimits="true" boundmass="1e-06" boundinertia="1e-12" angle="radian" eulerseq="XYZ" convexhull="true" fusestatic="true"/>
-  <option timestep="0.0001" gravity="0 0 -9810" integrator="Euler" solver="Newton" iterations="1000" tolerance="1e-12" noslip_iterations="100" noslip_tolerance="1e-08" mpr_iterations="100" collision="predefined">
+  <option timestep="0.0001" gravity="0 0 -9810" integrator="Euler" solver="Newton" iterations="1000" tolerance="1e-12" noslip_iterations="100" noslip_tolerance="1e-08" mpr_iterations="100">
     <flag multiccd="enable" energy="enable"/> <!--multiccd seems to fix leg penetrating the floor-->
   </option>
   <size njmax="4096" nconmax="4096"/>

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(),
     package_data={"flygym": ["data/*"], "flygym.mujoco": ["mujoco/config.yaml"]},
     include_package_data=True,
-    python_requires=">=3.7,<3.12",
+    python_requires=">=3.8,<3.12",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(),
     package_data={"flygym": ["data/*"], "flygym.mujoco": ["mujoco/config.yaml"]},
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.7,<3.12",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
@@ -28,7 +28,7 @@ setup(
         "tqdm",
     ],
     extras_require={
-        "mujoco": ["mujoco>=2.3.0,<3.0.0", "dm_control", "numba", "opencv-python"],
+        "mujoco": ["mujoco>=3.0.0", "dm_control", "numba", "opencv-python"],
         "pybullet": ["pybullet"],
         "dev": [
             "sphinx",


### PR DESCRIPTION
### Description
- Modify model file to support MuJoCo 3.x.x
- Remove support for Python 3.7 (too old; not supported by MuJoCo 3.x.x)
- Remove support for Python 3.12 (too new; not supported by Numba)

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#111 