### PR TITLE
HybridTurningNMF: clear CPG's intrinsic freqs and amps during reset

### DIFF
--- a/flygym/mujoco/examples/turning_controller.py
+++ b/flygym/mujoco/examples/turning_controller.py
@@ -170,6 +170,8 @@ class HybridTurningNMF(NeuroMechFly):
     def reset(self, seed=None, init_phases=None, init_magnitudes=None, **kwargs):
         obs, info = super().reset(seed=seed)
         self.cpg_network.random_state = np.random.RandomState(seed)
+        self.cpg_network.intrinsic_amps = self.intrinsic_amps
+        self.cpg_network.intrinsic_freqs = self.intrinsic_freqs
         self.cpg_network.reset(init_phases, init_magnitudes)
         self.retraction_correction = np.zeros(6)
         self.stumbling_correction = np.zeros(6)


### PR DESCRIPTION
### Description
CPG network's intrinsic frequency and amplitude are not reset properly in HybridTurningNMF.reset(). This leads to non-deterministic simulation if Gymnasium's check_env function is used. This functions resets the environment few times (with different seeds) and makes a step, so actual simulation starts with non-deterministic initial state of CPG.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
https://github.com/NeLy-EPFL/flygym/issues/116