### PR TITLE
Bux fix: `.reset()` doesn't return "vision_updated" in `info`

### DIFF
--- a/flygym/mujoco/core.py
+++ b/flygym/mujoco/core.py
@@ -1222,7 +1222,11 @@ class NeuroMechFly(gym.Env):
         self._curr_visual_input = None
         self._vision_update_mask = []
         self._flip_counter = 0
-        return self.get_observation(), self.get_info()
+        obs = self.get_observation()
+        info = self.get_info()
+        if self.sim_params.enable_vision:
+            info["vision_updated"] = True
+        return obs, info
 
     def step(
         self, action: ObsType


### PR DESCRIPTION
`.reset()` doesn't return whether vision has been updated in `info`, as desired when `enable_vision==True`.

### Description
[describe your changes here]

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]