### PR TITLE
Fix bug in parallelized closed-loop plume tracking

### DIFF
--- a/flygym/examples/olfaction/track_plume_closed_loop.py
+++ b/flygym/examples/olfaction/track_plume_closed_loop.py
@@ -139,7 +139,9 @@ def run_simulation(
 
 def process_trial(plume_dataset_path, output_dir, seed, initial_position, is_control):
     try:
-        return run_simulation(
+        # Run_simulation returns a Simulation object, which is not
+        # pickle-able. Do not return it here in this wrapper.
+        run_simulation(
             plume_dataset_path,
             output_dir,
             seed,


### PR DESCRIPTION
### Description
At some point we made the `run_simulation` function return the Simulation object to facilitate testing. However this broke the parallel execution of the code because parallelization (at least via joblib) pickles the returned object in the reduce step. However, the Simulation object is not pickle-able. We now drop the returned value in the wrapper that encapsulates `run_simulation`.

### Does this address any currently open issues?
N/A