### PR TITLE
Purge pip cache more often to avoid occasional hashing issue

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -12,8 +12,11 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
+          pip install --upgrade pip
+          pip cache purge
           pip install sphinxcontrib-googleanalytics
           pip install "flyvision @ https://github.com/Nely-EPFL/flyvis/archive/refs/heads/main.zip"
+          pip cache purge
           pip install -e ."[dev,examples]"
           pip install toolz
       - name: Sphinx build

--- a/.github/workflows/tests_full.yaml
+++ b/.github/workflows/tests_full.yaml
@@ -26,6 +26,7 @@ jobs:
           pip install --upgrade pip
           pip cache purge
           pip install "flyvision @ https://github.com/Nely-EPFL/flyvis/archive/refs/heads/main.zip"
+          pip cache purge
           pip install -e ".[dev,examples]"
       - name: Lint with ruff
         run: |

--- a/.github/workflows/tests_macos.yaml
+++ b/.github/workflows/tests_macos.yaml
@@ -23,6 +23,7 @@ jobs:
           pip install --upgrade pip
           pip cache purge
           pip install "flyvision @ https://github.com/Nely-EPFL/flyvis/archive/refs/heads/main.zip"
+          pip cache purge
           pip install -e ".[dev,examples]"
       - name: Lint with ruff
         run: |

--- a/.github/workflows/tests_ubuntu22.yaml
+++ b/.github/workflows/tests_ubuntu22.yaml
@@ -26,6 +26,7 @@ jobs:
           pip install --upgrade pip
           pip cache purge
           pip install "flyvision @ https://github.com/Nely-EPFL/flyvis/archive/refs/heads/main.zip"
+          pip cache purge
           pip install -e ".[dev,examples]"
       - name: Lint with ruff
         run: |

--- a/.github/workflows/tests_windows.yaml
+++ b/.github/workflows/tests_windows.yaml
@@ -22,6 +22,7 @@ jobs:
           pip install --upgrade pip
           pip cache purge
           pip install "flyvision @ https://github.com/nely-epfl/flyvis/archive/refs/heads/main.zip"
+          pip cache purge
           pip install -e .[dev,examples]
       - name: Lint with ruff
         run: |


### PR DESCRIPTION
### Description
Occasionally pip install fails with caching issues in GitHub Action workflows.
Example: https://github.com/NeLy-EPFL/flygym/actions/runs/9612282740/job/26512586853
This aims to fix the problem by clearing the cache more often (maybe after installing flyvision cache should be cleared?)
This merge to main doesn't result in a new release because it only relates to the GitHub CI workflows (no code change).

### Does this address any currently open issues?
[list open issues here]