### PR TITLE
add default contact sensors

### DIFF
--- a/flygym/examples/path_integration/tests/test_integration.py
+++ b/flygym/examples/path_integration/tests/test_integration.py
@@ -205,7 +205,7 @@ def test_path_integration():
     # Name: (tripod, 0.64, 0.5, 1, 3, FMH), dtype: float64
 
     time_scale = 0.64
-    running_time = 1.0
+    running_time = 2.0
     dt = 1e-4
     heading_model = LinearModel(
         coefs_all=np.array([0.250722, 0.176886, 0.032141]),

--- a/flygym/preprogrammed.py
+++ b/flygym/preprogrammed.py
@@ -30,6 +30,12 @@ all_tarsi_links = [
     f"{side}{pos}Tarsus{i}" for side in "LR" for pos in "FMH" for i in range(1, 6)
 ]
 
+default_leg_sensor_placements = [
+    f"{leg}{segment}"
+    for leg in ["LF", "LM", "LH", "RF", "RM", "RH"]
+    for segment in ["Tibia", "Tarsus1", "Tarsus2", "Tarsus3", "Tarsus4", "Tarsus5"]
+]
+
 
 def get_preprogrammed_pose(pose: str) -> KinematicPose:
     """Load the preprogrammed pose given the key. Available poses are found


### PR DESCRIPTION
### Description
We have a lot of code that has something like this:
```python
contact_sensor_placements = [
    f"{leg}{segment}"
    for leg in ["LF", "LM", "LH", "RF", "RM", "RH"]
    for segment in ["Tibia", "Tarsus1", "Tarsus2", "Tarsus3", "Tarsus4", "Tarsus5"]
]

fly = HybridTurningFly(
    contact_sensor_placements=contact_sensor_placements,
    ...
)
```

It's nice to add this hardcoded `contact_sensor_placements` as `flygym.preprogrammed.default_leg_sensor_placements`.

### Does this address any currently open issues?
No