### PR TITLE
Fix website typos (no code change)

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,7 +20,7 @@ Simulating embodied sensorimotor control with NeuroMechFly v2
    changelog
    contributing
 
-`Preprint <https://www.biorxiv.org/content/10.1101/2023.09.18.556649>`_ |
+`Paper <https://www.epfl.ch/labs/ramdya-lab/wp-content/uploads/2024/08/NMF2_postprint.pdf>`_ |
 `GitHub <https://github.com/NeLy-EPFL/flygym>`_
 
 .. figure:: https://github.com/NeLy-EPFL/_media/blob/main/flygym/overview_video.gif?raw=true
@@ -33,7 +33,7 @@ Simulating embodied sensorimotor control with NeuroMechFly v2
    API changes may occur in future releases. See the `changelog <changelog.html>`_ for details.
 
 
-FlyGym is the Python library for NeuroMechFly v2, a digital twin of the adult fruit fly *Drosophila melanogaster* that can see, smell, walk over challenging terrain, and interact with the environment (see our `NeuroMechFly v2 paper <https://www.biorxiv.org/content/10.1101/2023.09.18.556649>`_).
+FlyGym is the Python library for NeuroMechFly v2, a digital twin of the adult fruit fly *Drosophila melanogaster* that can see, smell, walk over challenging terrain, and interact with the environment (see our `NeuroMechFly v2 paper <https://www.epfl.ch/labs/ramdya-lab/wp-content/uploads/2024/08/NMF2_postprint.pdf>`_).
 
 FlyGym consists of the following components:
 

--- a/doc/source/sfn2024.rst
+++ b/doc/source/sfn2024.rst
@@ -5,7 +5,29 @@ Workshop @ SfN
 
     <style>
         h2.smaller {font-size: 25px;}
+
         h3.smaller {font-size: 20px;}
+        
+        .register-button {
+            display: inline-block;
+            padding: 10px 30px;
+            font-size: 18px;
+            font-weight: bold;
+            color: white;
+            background-color: #5c24f5; /* Adjust this color to match your theme */
+            border: none;
+            border-radius: 5px;
+            text-align: center;
+            text-decoration: none;
+            transition: background-color 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .register-button:hover {
+            background-color: #dfd3fd; /* Darker shade for hover effect */
+            color: #5c24f5; /* Text color for hover effect */
+            box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+        }
+
     </style>
 
     <h2 class="smaller">Simulating embodied sensorimotor control with NeuroMechFly</h2>
@@ -18,9 +40,13 @@ Workshop @ SfN
     <b>Where:</b> <a href="https://maps.app.goo.gl/RAt117EM99RaRHeNA" target="_blank" rel="noopener noreferrer"> Hyatt Regency McCormick Place, 2233 S. Martin Luther King Drive, Chicago</a></br>
     <b>Organized by:</b> Pavan Ramdya, Sibo Wang-Chen, Victor Stimpfling, Thomas Lam</br>
     <b>Practical information:</b></br>
-    &#8227; To attend, please register using <a href="https://forms.gle/a6mMxM3A3c8287pW8" target="_blank" rel="noopener noreferrer">this Google Form</a>.</br>
+    &#8227; To attend, please register using the button below.</br>
     &#8227; Please bring your own laptop for the coding sessions.
     </p>
+    </div>
+
+    <div style="text-align: center;">
+        <a href="https://forms.gle/a6mMxM3A3c8287pW8"  target="_blank" rel="noopener noreferrer" class="register-button">Register</a>
     </div>
 
     <h3 class="smaller">Background</h3>

--- a/doc/source/sfn2024.rst
+++ b/doc/source/sfn2024.rst
@@ -15,7 +15,7 @@ Workshop @ SfN
     <p class="admonition-title" style="font-weight: bold; font-size: 12pt">Important</p>
     <p style="font-size: 12pt">
     <b>When:</b> Monday October 7 (SfN Day 3), 6:30 pm &ndash; 8:30 pm</br>
-    <b>When:</b> <a href="https://maps.app.goo.gl/RAt117EM99RaRHeNA" target="_blank" rel="noopener noreferrer"> Hyatt Regency McCormick Place, 2233 S. Martin Luther King Drive, Chicago</a></br>
+    <b>Where:</b> <a href="https://maps.app.goo.gl/RAt117EM99RaRHeNA" target="_blank" rel="noopener noreferrer"> Hyatt Regency McCormick Place, 2233 S. Martin Luther King Drive, Chicago</a></br>
     <b>Organized by:</b> Pavan Ramdya, Sibo Wang-Chen, Victor Stimpfling, Thomas Lam</br>
     <b>Practical information:</b></br>
     &#8227; To attend, please register using <a href="https://forms.gle/a6mMxM3A3c8287pW8" target="_blank" rel="noopener noreferrer">this Google Form</a>.</br>

--- a/flygym/arena/base.py
+++ b/flygym/arena/base.py
@@ -21,7 +21,6 @@ class BaseArena(ABC):
     friction = (100.0, 0.005, 0.0001)
 
     def __init__(self, *args: list, **kwargs: dict):
-        """Create a new terrain object."""
         self.root_element = mjcf.RootElement()
         self.init_lights()
 

--- a/flygym/camera.py
+++ b/flygym/camera.py
@@ -72,7 +72,7 @@ class Camera:
     output_path : Optional[Union[str, Path]]
         Path to which the rendered video should be saved. If None, the
         video will not be saved.
-    
+
     Parameters
     ----------
     fly : Fly

--- a/flygym/camera.py
+++ b/flygym/camera.py
@@ -72,6 +72,66 @@ class Camera:
     output_path : Optional[Union[str, Path]]
         Path to which the rendered video should be saved. If None, the
         video will not be saved.
+    
+    Parameters
+    ----------
+    fly : Fly
+        The fly to which the camera is associated.
+    camera_id : str
+        The camera that will be used for rendering, by default
+        "Animat/camera_left".
+    window_size : tuple[int, int]
+        Size of the rendered images in pixels, by default (640, 480).
+    play_speed : float
+        Play speed of the rendered video, by default 0.2.
+    fps: int
+        FPS of the rendered video when played at ``play_speed``, by
+        default 30.
+    timestamp_text : bool
+        If True, text indicating the current simulation time will be
+        added to the rendered video.
+    play_speed_text : bool
+        If True, text indicating the play speed will be added to the
+        rendered video.
+    draw_contacts : bool
+        If True, arrows will be drawn to indicate contact forces
+        between the legs and the ground. By default False.
+    decompose_contacts : bool
+        If True, the arrows visualizing contact forces will be
+        decomposed into x-y-z components. By default True.
+    force_arrow_scaling : float, optional
+        Scaling factor determining the length of arrows visualizing
+        contact forces. By default 1.0 if perspective_arrow_length
+        is True and 10.0 otherwise.
+    tip_length : float
+        Size of the arrows indicating the contact forces in pixels. By
+        default 10.
+    contact_threshold : float
+        The threshold for contact detection in mN (forces below this
+        magnitude will be ignored). By default 0.1.
+    draw_gravity : bool
+        If True, an arrow will be drawn indicating the direction of
+        gravity. This is useful during climbing simulations. By default
+        False.
+    gravity_arrow_scaling : float
+        Scaling factor determining the size of the arrow indicating
+        gravity. By default 0.0001.
+    align_camera_with_gravity : bool
+        If True, the camera will be rotated such that gravity points
+        down. This is useful during climbing simulations. By default
+        False.
+    camera_follows_fly_orientation : bool
+        If True, the camera will be rotated so that it aligns with the
+        fly's orientation. By default False.
+    decompose_colors
+        Colors for the x, y, and z components of the contact force
+        arrows. By default ((255, 0, 0), (0, 255, 0), (0, 0, 255)).
+    output_path : str or Path, optional
+        Path to which the rendered video should be saved. If None, the
+        video will not be saved. By default None.
+    perspective_arrow_length : bool
+        If true, the length of the arrows indicating the contact forces
+        will be determined by the perspective.
     """
 
     dm_camera: dm_control.mujoco.Camera
@@ -100,68 +160,6 @@ class Camera:
         output_path: Optional[Union[str, Path]] = None,
         perspective_arrow_length=False,
     ):
-        """Initialize a Camera.
-
-        Parameters
-        ----------
-        fly : Fly
-            The fly to which the camera is associated.
-        camera_id : str
-            The camera that will be used for rendering, by default
-            "Animat/camera_left".
-        window_size : tuple[int, int]
-            Size of the rendered images in pixels, by default (640, 480).
-        play_speed : float
-            Play speed of the rendered video, by default 0.2.
-        fps: int
-            FPS of the rendered video when played at ``play_speed``, by
-            default 30.
-        timestamp_text : bool
-            If True, text indicating the current simulation time will be
-            added to the rendered video.
-        play_speed_text : bool
-            If True, text indicating the play speed will be added to the
-            rendered video.
-        draw_contacts : bool
-            If True, arrows will be drawn to indicate contact forces
-            between the legs and the ground. By default False.
-        decompose_contacts : bool
-            If True, the arrows visualizing contact forces will be
-            decomposed into x-y-z components. By default True.
-        force_arrow_scaling : float, optional
-            Scaling factor determining the length of arrows visualizing
-            contact forces. By default 1.0 if perspective_arrow_length
-            is True and 10.0 otherwise.
-        tip_length : float
-            Size of the arrows indicating the contact forces in pixels. By
-            default 10.
-        contact_threshold : float
-            The threshold for contact detection in mN (forces below this
-            magnitude will be ignored). By default 0.1.
-        draw_gravity : bool
-            If True, an arrow will be drawn indicating the direction of
-            gravity. This is useful during climbing simulations. By default
-            False.
-        gravity_arrow_scaling : float
-            Scaling factor determining the size of the arrow indicating
-            gravity. By default 0.0001.
-        align_camera_with_gravity : bool
-            If True, the camera will be rotated such that gravity points
-            down. This is useful during climbing simulations. By default
-            False.
-        camera_follows_fly_orientation : bool
-            If True, the camera will be rotated so that it aligns with the
-            fly's orientation. By default False.
-        decompose_colors
-            Colors for the x, y, and z components of the contact force
-            arrows. By default ((255, 0, 0), (0, 255, 0), (0, 0, 255)).
-        output_path : str or Path, optional
-            Path to which the rendered video should be saved. If None, the
-            video will not be saved. By default None.
-        perspective_arrow_length : bool
-            If true, the length of the arrows indicating the contact forces
-            will be determined by the perspective.
-        """
         self.fly = fly
         self.window_size = window_size
         self.play_speed = play_speed

--- a/flygym/core.py
+++ b/flygym/core.py
@@ -253,7 +253,7 @@ class NeuroMechFly(SingleFlySimulation):
         in which time steps the visual inputs have been refreshed. In other
         words, the visual input frames where this mask is False are
         repetitions of the previous updated visual input frames.
-    
+
     Parameters
     ----------
     sim_params : flygym.Parameters

--- a/flygym/core.py
+++ b/flygym/core.py
@@ -253,6 +253,63 @@ class NeuroMechFly(SingleFlySimulation):
         in which time steps the visual inputs have been refreshed. In other
         words, the visual input frames where this mask is False are
         repetitions of the previous updated visual input frames.
+    
+    Parameters
+    ----------
+    sim_params : flygym.Parameters
+        Parameters of the MuJoCo simulation.
+    actuated_joints : list[str], optional
+        List of names of actuated joints. By default all active leg
+        DoFs.
+    contact_sensor_placements : list[str], optional
+        List of body segments where contact sensors are placed. By
+        default all tarsus segments.
+    output_dir : Path, optional
+        Directory to save simulation data. If ``None``, no data will
+        be saved. By default None.
+    arena : flygym.arena.BaseArena, optional
+        The arena in which the fly is placed. ``FlatTerrain`` will be
+        used if not specified.
+    xml_variant: str or Path, optional
+        The variant of the fly model to use. Multiple variants exist
+        because when replaying experimentally recorded behavior, the
+        ordering of DoF angles in multi-DoF joints depends on how they
+        are configured in the upstream inverse kinematics program. Two
+        variants are provided: "seqik" (default) and "deepfly3d" (for
+        legacy data produced by DeepFly3D, Gunel et al., eLife, 2019).
+        The ordering of DoFs can be seen from the XML files under
+        ``flygym/data/mjcf/``.
+    spawn_pos : tuple[float, float, float], optional
+        The (x, y, z) position in the arena defining where the fly
+        will be spawn, in mm. By default (0, 0, 0.5).
+    spawn_orientation : tuple[float, float, float], optional
+        The spawn orientation of the fly in the Euler angle format:
+        (x, y, z), where x, y, z define the rotation around x, y and
+        z in radian. By default (0.0, 0.0, pi/2), which leads to a
+        position facing the positive direction of the x-axis.
+    control : str, optional
+        The joint controller type. Can be "position", "velocity", or
+        "torque", by default "position".
+    init_pose : BaseState, optional
+        Which initial pose to start the simulation from. By default
+        "stretch" kinematic pose with all legs fully stretched.
+    floor_collisions :str
+        Which set of collisions should collide with the floor. Can be
+        "all", "legs", "tarsi" or a list of body names. By default
+        "legs".
+    self_collisions : str
+        Which set of collisions should collide with each other. Can be
+        "all", "legs", "legs-no-coxa", "tarsi", "none", or a list of
+        body names. By default "legs".
+    detect_flip : bool
+        If True, the simulation will indicate whether the fly has
+        flipped in the ``info`` returned by ``.step(...)``. Flip
+        detection is achieved by checking whether the leg tips are free
+        of any contact for a duration defined in the configuration
+        file. Flip detection is disabled for a period of time at the
+        beginning of the simulation as defined in the configuration
+        file. This avoids spurious detection when the fly is not
+        standing reliably on the ground yet. By default False.
     """
 
     def __init__(
@@ -271,66 +328,6 @@ class NeuroMechFly(SingleFlySimulation):
         self_collisions: Union[str, list[str]] = "legs",
         detect_flip: bool = False,
     ) -> None:
-        """Initialize a NeuroMechFly environment.
-
-        Parameters
-        ----------
-        sim_params : flygym.Parameters
-            Parameters of the MuJoCo simulation.
-        actuated_joints : list[str], optional
-            List of names of actuated joints. By default all active leg
-            DoFs.
-        contact_sensor_placements : list[str], optional
-            List of body segments where contact sensors are placed. By
-            default all tarsus segments.
-        output_dir : Path, optional
-            Directory to save simulation data. If ``None``, no data will
-            be saved. By default None.
-        arena : flygym.arena.BaseArena, optional
-            The arena in which the fly is placed. ``FlatTerrain`` will be
-            used if not specified.
-        xml_variant: str or Path, optional
-            The variant of the fly model to use. Multiple variants exist
-            because when replaying experimentally recorded behavior, the
-            ordering of DoF angles in multi-DoF joints depends on how they
-            are configured in the upstream inverse kinematics program. Two
-            variants are provided: "seqik" (default) and "deepfly3d" (for
-            legacy data produced by DeepFly3D, Gunel et al., eLife, 2019).
-            The ordering of DoFs can be seen from the XML files under
-            ``flygym/data/mjcf/``.
-        spawn_pos : tuple[float, float, float], optional
-            The (x, y, z) position in the arena defining where the fly
-            will be spawn, in mm. By default (0, 0, 0.5).
-        spawn_orientation : tuple[float, float, float], optional
-            The spawn orientation of the fly in the Euler angle format:
-            (x, y, z), where x, y, z define the rotation around x, y and
-            z in radian. By default (0.0, 0.0, pi/2), which leads to a
-            position facing the positive direction of the x-axis.
-        control : str, optional
-            The joint controller type. Can be "position", "velocity", or
-            "torque", by default "position".
-        init_pose : BaseState, optional
-            Which initial pose to start the simulation from. By default
-            "stretch" kinematic pose with all legs fully stretched.
-        floor_collisions :str
-            Which set of collisions should collide with the floor. Can be
-            "all", "legs", "tarsi" or a list of body names. By default
-            "legs".
-        self_collisions : str
-            Which set of collisions should collide with each other. Can be
-            "all", "legs", "legs-no-coxa", "tarsi", "none", or a list of
-            body names. By default "legs".
-        detect_flip : bool
-            If True, the simulation will indicate whether the fly has
-            flipped in the ``info`` returned by ``.step(...)``. Flip
-            detection is achieved by checking whether the leg tips are free
-            of any contact for a duration defined in the configuration
-            file. Flip detection is disabled for a period of time at the
-            beginning of the simulation as defined in the configuration
-            file. This avoids spurious detection when the fly is not
-            standing reliably on the ground yet. By default False.
-        """
-
         warnings.warn(
             "Deprecation warning: The `NeuroMechFly` class has been "
             "restructured into `Simulation`, `Fly`, and `Camera`."

--- a/flygym/examples/head_stabilization/data.py
+++ b/flygym/examples/head_stabilization/data.py
@@ -120,7 +120,7 @@ class WalkingDataset(Dataset):
     contact_mask : np.ndarray
         The contact force mask (i.e., 1 if leg touching the floor, 0
         otherwise). The shape is (n_samples, 6).
-    
+
     Parameters
     ----------
     sim_data_file : Path

--- a/flygym/examples/head_stabilization/data.py
+++ b/flygym/examples/head_stabilization/data.py
@@ -87,19 +87,6 @@ class WalkingDataset(Dataset):
     """
     PyTorch Dataset class for walking data.
 
-    Parameters
-    ----------
-    sim_data_file : Path
-        The path to the simulation data file.
-    contact_force_thr : tuple[float, float, float], optional
-        The threshold values for contact forces, by default (0.5, 1, 3).
-    joint_angle_scaler : Optional[Callable], optional
-        A callable object used to scale joint angles, by default None.
-    ignore_first_n : int, optional
-        The number of initial data points to ignore, by default 200.
-    joint_mask : Optional, optional
-        A mask to apply on joint angles, by default None.
-
     Attributes
     ----------
     gait : str
@@ -133,6 +120,19 @@ class WalkingDataset(Dataset):
     contact_mask : np.ndarray
         The contact force mask (i.e., 1 if leg touching the floor, 0
         otherwise). The shape is (n_samples, 6).
+    
+    Parameters
+    ----------
+    sim_data_file : Path
+        The path to the simulation data file.
+    contact_force_thr : tuple[float, float, float], optional
+        The threshold values for contact forces, by default (0.5, 1, 3).
+    joint_angle_scaler : Optional[Callable], optional
+        A callable object used to scale joint angles, by default None.
+    ignore_first_n : int, optional
+        The number of initial data points to ignore, by default 200.
+    joint_mask : Optional, optional
+        A mask to apply on joint angles, by default None.
     """
 
     def __init__(

--- a/flygym/examples/head_stabilization/model.py
+++ b/flygym/examples/head_stabilization/model.py
@@ -77,6 +77,16 @@ class HeadStabilizationInferenceWrapper:
     training, this class provides a "flat" interface for making predictions
     one observation (i.e., time step) at a time. This is useful for
     deploying the model in closed loop.
+
+    Parameters
+    ----------
+    model_path : Path
+        The path to the trained model.
+    scaler_param_path : Path
+        The path to the pickle file containing scaler parameters.
+    contact_force_thr : tuple[float, float, float], optional
+        The threshold values for contact forces that are used to
+        determine the floor contact flags, by default (0.5, 1, 3).
     """
 
     def __init__(
@@ -85,17 +95,6 @@ class HeadStabilizationInferenceWrapper:
         scaler_param_path: Path,
         contact_force_thr: tuple[float, float, float] = (0.5, 1, 3),
     ):
-        """
-        Parameters
-        ----------
-        model_path : Path
-            The path to the trained model.
-        scaler_param_path : Path
-            The path to the pickle file containing scaler parameters.
-        contact_force_thr : tuple[float, float, float], optional
-            The threshold values for contact forces that are used to
-            determine the floor contact flags, by default (0.5, 1, 3).
-        """
         # Load scaler params
         with open(scaler_param_path, "rb") as f:
             scaler_params = pickle.load(f)

--- a/flygym/examples/locomotion/rule_based_controller.py
+++ b/flygym/examples/locomotion/rule_based_controller.py
@@ -6,6 +6,23 @@ from flygym.examples.locomotion import PreprogrammedSteps
 
 
 class RuleBasedController:
+    """
+    Parameters
+    ----------
+    timestep : float
+        The timestep of the simulation.
+    rules_graph : nx.MultiDiGraph
+        The rules graph that defines the interactions between the legs.
+    weights : dict
+        The weights for each rule.
+    preprogrammed_steps : PreprogrammedSteps, optional
+        Preprogrammed steps to be used for leg movement.
+    margin : float, optional
+        The margin for selecting the highest scoring leg.
+    seed : int, optional
+        The random seed to use for selecting the highest scoring leg.
+    """
+
     legs = ["LF", "LM", "LH", "RF", "RM", "RH"]
 
     def __init__(
@@ -20,22 +37,6 @@ class RuleBasedController:
         self._phase_inc_per_step = (
             2 * np.pi * (timestep / self.preprogrammed_steps.duration)
         )
-        """
-        Parameters
-        ----------
-        timestep : float
-            The timestep of the simulation.
-        rules_graph : nx.MultiDiGraph
-            The rules graph that defines the interactions between the legs.
-        weights : dict
-            The weights for each rule.
-        preprogrammed_steps : PreprogrammedSteps, optional
-            Preprogrammed steps to be used for leg movement.
-        margin : float, optional
-            The margin for selecting the highest scoring leg.
-        seed : int, optional
-            The random seed to use for selecting the highest scoring leg.
-        """
         self.curr_step = 0
 
         self.rule1_scores = np.zeros(6)

--- a/flygym/examples/locomotion/turning_controller.py
+++ b/flygym/examples/locomotion/turning_controller.py
@@ -51,6 +51,57 @@ class HybridTurningController(SingleFlySimulation):
     of the API references for the detailed specifications of the action
     space, the observation space, the reward, the "terminated" and
     "truncated" flags, and the "info" dictionary.
+
+    Parameters
+    ----------
+    fly : Fly
+        The fly object to be simulated.
+    preprogrammed_steps : PreprogrammedSteps, optional
+        Preprogrammed steps to be used for leg movement.
+    intrinsic_freqs : np.ndarray, optional
+        Intrinsic frequencies of the CPGs. See ``CPGNetwork`` for
+        details.
+    intrinsic_amps : np.ndarray, optional
+        Intrinsic amplitudes of the CPGs. See ``CPGNetwork`` for
+        details.
+    phase_biases : np.ndarray, optional
+        Phase biases of the CPGs. See ``CPGNetwork`` for details.
+    coupling_weights : np.ndarray, optional
+        Coupling weights of the CPGs. See ``CPGNetwork`` for details.
+    convergence_coefs : np.ndarray, optional
+        Convergence coefficients of the CPGs. See ``CPGNetwork`` for
+        details.
+    init_phases : np.ndarray, optional
+        Initial phases of the CPGs. See ``CPGNetwork`` for details.
+    init_magnitudes : np.ndarray, optional
+        Initial magnitudes of the CPGs. See ``CPGNetwork`` for details.
+    stumble_segments : tuple, optional
+        Leg segments to be used for stumbling detection.
+    stumbling_force_threshold : float, optional
+        Threshold for stumbling detection.
+    correction_vectors : dict, optional
+        Correction vectors for each leg.
+    correction_rates : dict, optional
+        Correction rates for retraction and stumbling.
+    amplitude_range : tuple, optional
+        Range for leg lifting correction.
+    draw_corrections : bool, optional
+        Whether to color-code legs to indicate if correction rules
+        are active in the rendered video.
+    max_increment : float, optional
+        Maximum duration of the correction before it is capped.
+    retraction_persist3nce_duration : float, optional
+        Time spend in a persistent state (leg is further retracted)
+        even if the rule is no longer active
+    retraction_persist3nce_initiation_threshold : float, optional
+        Amount of time the leg had to be retracted for for the persistence
+        to be initiated (prevents activation of persistence for noise driven
+        rule activations)
+    seed : int, optional
+        Seed for the random number generator.
+    **kwargs
+        Additional keyword arguments to be passed to
+        ``SingleFlySimulation.__init__``.
     """
 
     def __init__(
@@ -76,58 +127,6 @@ class HybridTurningController(SingleFlySimulation):
         seed=0,
         **kwargs,
     ):
-        """
-        Parameters
-        ----------
-        fly : Fly
-            The fly object to be simulated.
-        preprogrammed_steps : PreprogrammedSteps, optional
-            Preprogrammed steps to be used for leg movement.
-        intrinsic_freqs : np.ndarray, optional
-            Intrinsic frequencies of the CPGs. See ``CPGNetwork`` for
-            details.
-        intrinsic_amps : np.ndarray, optional
-            Intrinsic amplitudes of the CPGs. See ``CPGNetwork`` for
-            details.
-        phase_biases : np.ndarray, optional
-            Phase biases of the CPGs. See ``CPGNetwork`` for details.
-        coupling_weights : np.ndarray, optional
-            Coupling weights of the CPGs. See ``CPGNetwork`` for details.
-        convergence_coefs : np.ndarray, optional
-            Convergence coefficients of the CPGs. See ``CPGNetwork`` for
-            details.
-        init_phases : np.ndarray, optional
-            Initial phases of the CPGs. See ``CPGNetwork`` for details.
-        init_magnitudes : np.ndarray, optional
-            Initial magnitudes of the CPGs. See ``CPGNetwork`` for details.
-        stumble_segments : tuple, optional
-            Leg segments to be used for stumbling detection.
-        stumbling_force_threshold : float, optional
-            Threshold for stumbling detection.
-        correction_vectors : dict, optional
-            Correction vectors for each leg.
-        correction_rates : dict, optional
-            Correction rates for retraction and stumbling.
-        amplitude_range : tuple, optional
-            Range for leg lifting correction.
-        draw_corrections : bool, optional
-            Whether to color-code legs to indicate if correction rules
-            are active in the rendered video.
-        max_increment : float, optional
-            Maximum duration of the correction before it is capped.
-        retraction_persist3nce_duration : float, optional
-            Time spend in a persistent state (leg is further retracted)
-            even if the rule is no longer active
-        retraction_persist3nce_initiation_threshold : float, optional
-            Amount of time the leg had to be retracted for for the persistence
-            to be initiated (prevents activation of persistence for noise driven
-            rule activations)
-        seed : int, optional
-            Seed for the random number generator.
-        **kwargs
-            Additional keyword arguments to be passed to
-            ``SingleFlySimulation.__init__``.
-        """
         # Check if we have the correct list of actuated joints
         if fly.actuated_joints != all_leg_dofs:
             raise ValueError(

--- a/flygym/examples/locomotion/turning_fly.py
+++ b/flygym/examples/locomotion/turning_fly.py
@@ -45,6 +45,55 @@ class HybridTurningFly(Fly):
     stumbling and retraction. The controller also receives a 2D descending
     input to modulate the amplitudes and frequencies of the CPGs to
     accomplish turning.
+
+    Parameters
+    ----------
+    preprogrammed_steps : PreprogrammedSteps, optional
+        Preprogrammed steps to be used for leg movement.
+    intrinsic_freqs : np.ndarray, optional
+        Intrinsic frequencies of the CPGs. See ``CPGNetwork`` for
+        details.
+    intrinsic_amps : np.ndarray, optional
+        Intrinsic amplitudes of the CPGs. See ``CPGNetwork`` for
+        details.
+    phase_biases : np.ndarray, optional
+        Phase biases of the CPGs. See ``CPGNetwork`` for details.
+    coupling_weights : np.ndarray, optional
+        Coupling weights of the CPGs. See ``CPGNetwork`` for details.
+    convergence_coefs : np.ndarray, optional
+        Convergence coefficients of the CPGs. See ``CPGNetwork`` for
+        details.
+    init_phases : np.ndarray, optional
+        Initial phases of the CPGs. See ``CPGNetwork`` for details.
+    init_magnitudes : np.ndarray, optional
+        Initial magnitudes of the CPGs. See ``CPGNetwork`` for details.
+    stumble_segments : tuple, optional
+        Leg segments to be used for stumbling detection.
+    stumbling_force_threshold : float, optional
+        Threshold for stumbling detection.
+    correction_vectors : dict, optional
+        Correction vectors for each leg.
+    correction_rates : dict, optional
+        Correction rates for retraction and stumbling.
+    amplitude_range : tuple, optional
+        Range for leg lifting correction.
+    draw_corrections : bool, optional
+        Whether to color-code legs to indicate if correction rules
+        are active in the rendered video.
+    max_increment : float, optional
+        Maximum duration of the correction before it is capped.
+    retraction_persistence_duration : float, optional
+        Time spend in a persistent state (leg is further retracted)
+        even if the rule is no longer active
+    retraction_persistence_initiation_threshold : float, optional
+        Amount of time the leg had to be retracted for for the persistence
+        to be initiated (prevents activation of persistence for noise driven
+        rule activations)
+    seed : int, optional
+        Seed for the random number generator.
+    **kwargs
+        Additional keyword arguments to be passed to
+        ``SingleFlySimulation.__init__``.
     """
 
     def __init__(
@@ -70,56 +119,6 @@ class HybridTurningFly(Fly):
         seed=0,
         **kwargs,
     ):
-        """
-        Parameters
-        ----------
-        preprogrammed_steps : PreprogrammedSteps, optional
-            Preprogrammed steps to be used for leg movement.
-        intrinsic_freqs : np.ndarray, optional
-            Intrinsic frequencies of the CPGs. See ``CPGNetwork`` for
-            details.
-        intrinsic_amps : np.ndarray, optional
-            Intrinsic amplitudes of the CPGs. See ``CPGNetwork`` for
-            details.
-        phase_biases : np.ndarray, optional
-            Phase biases of the CPGs. See ``CPGNetwork`` for details.
-        coupling_weights : np.ndarray, optional
-            Coupling weights of the CPGs. See ``CPGNetwork`` for details.
-        convergence_coefs : np.ndarray, optional
-            Convergence coefficients of the CPGs. See ``CPGNetwork`` for
-            details.
-        init_phases : np.ndarray, optional
-            Initial phases of the CPGs. See ``CPGNetwork`` for details.
-        init_magnitudes : np.ndarray, optional
-            Initial magnitudes of the CPGs. See ``CPGNetwork`` for details.
-        stumble_segments : tuple, optional
-            Leg segments to be used for stumbling detection.
-        stumbling_force_threshold : float, optional
-            Threshold for stumbling detection.
-        correction_vectors : dict, optional
-            Correction vectors for each leg.
-        correction_rates : dict, optional
-            Correction rates for retraction and stumbling.
-        amplitude_range : tuple, optional
-            Range for leg lifting correction.
-        draw_corrections : bool, optional
-            Whether to color-code legs to indicate if correction rules
-            are active in the rendered video.
-        max_increment : float, optional
-            Maximum duration of the correction before it is capped.
-        retraction_persistence_duration : float, optional
-            Time spend in a persistent state (leg is further retracted)
-            even if the rule is no longer active
-        retraction_persistence_initiation_threshold : float, optional
-            Amount of time the leg had to be retracted for for the persistence
-            to be initiated (prevents activation of persistence for noise driven
-            rule activations)
-        seed : int, optional
-            Seed for the random number generator.
-        **kwargs
-            Additional keyword arguments to be passed to
-            ``SingleFlySimulation.__init__``.
-        """
         self.timestep = timestep
         # Initialize fly
         super().__init__(**kwargs)

--- a/flygym/examples/olfaction/plume_tracking_arena.py
+++ b/flygym/examples/olfaction/plume_tracking_arena.py
@@ -14,6 +14,26 @@ class OdorPlumeArena(BaseArena):
     odor plume. The plume simulation is stored in an HDF5 file. In this
     class, we implement logics that calculate the intensity of the odor
     at the fly's location at the correct time.
+
+    Parameters
+    ----------
+    plume_data_path : Path
+        Path to the HDF5 file containing the plume simulation data.
+    dimension_scale_factor : float, optional
+        Scaling factor for the plume simulation grid. Each cell in the
+        plume grid is this many millimeters in the simulation. By
+        default 0.5.
+    plume_simulation_fps : float, optional
+        Frame rate of the plume simulation. Each frame in the plume
+        dataset is ``1 / plume_simulation_fps`` seconds in the physics
+        simulation. By default 200.
+    intensity_scale_factor : float, optional
+        Scaling factor for the intensity of the odor. By default 1.0.
+    friction : tuple[float, float, float], optional
+        Friction parameters for the floor geom. By default (1, 0.005,
+        0.0001).
+    num_sensors : int, optional
+        Number of olfactory sensors on the fly. By default 4.
     """
 
     def __init__(
@@ -25,27 +45,6 @@ class OdorPlumeArena(BaseArena):
         friction: tuple[float, float, float] = (1, 0.005, 0.0001),
         num_sensors: int = 4,
     ):
-        """
-        Parameters
-        ----------
-        plume_data_path : Path
-            Path to the HDF5 file containing the plume simulation data.
-        dimension_scale_factor : float, optional
-            Scaling factor for the plume simulation grid. Each cell in the
-            plume grid is this many millimeters in the simulation. By
-            default 0.5.
-        plume_simulation_fps : float, optional
-            Frame rate of the plume simulation. Each frame in the plume
-            dataset is ``1 / plume_simulation_fps`` seconds in the physics
-            simulation. By default 200.
-        intensity_scale_factor : float, optional
-            Scaling factor for the intensity of the odor. By default 1.0.
-        friction : tuple[float, float, float], optional
-            Friction parameters for the floor geom. By default (1, 0.005,
-            0.0001).
-        num_sensors : int, optional
-            Number of olfactory sensors on the fly. By default 4.
-        """
         super().__init__()
 
         self.dimension_scale_factor = dimension_scale_factor

--- a/flygym/examples/olfaction/plume_tracking_controller.py
+++ b/flygym/examples/olfaction/plume_tracking_controller.py
@@ -22,6 +22,52 @@ class PlumeNavigationController:
     turning, and stopping. The transition among these states are governed by Poisson
     processes with encounter-dependent rates.
 
+    Parameters
+    ----------
+    dt : float
+        Time step of the physics simulation in seconds.
+    forward_dn_drive : tuple[float, float]
+        Drive values for forward walking.
+    left_turn_dn_drive : tuple[float, float]
+        Drive values for left turn.
+    right_turn_dn_drive : tuple[float, float]
+        Drive values for right turn.
+    stop_dn_drive : tuple[float, float]
+        Drive values for stopping.
+    turn_duration : float
+        Duration of the turn in seconds.
+    lambda_ws_0 : float
+        Baseline rate of transition from walking to stopping.
+    delta_lambda_ws : float
+        Change in the rate of transition from walking to stopping after an
+        encounter.
+    tau_s : float
+        Time constant for the transition from walking to stopping.
+    alpha : float
+        Parameter for the sigmoid function that determines the turning direction.
+    tau_freq_conv : float
+        Time constant for the exponential kernel that convolves the encounter
+        history to determine the turning direction.
+    cumulative_evidence_window : float
+        Window size for the cumulative evidence of the encounter history. In other
+        words, encounters more than this many seconds ago are ignored.
+    lambda_sw_0 : float
+        Baseline rate of transition from stopping to walking.
+    delta_lambda_sw : float
+        Maximum change in the rate of transition from stopping to walking after an
+        encounter.
+    tau_w : float
+        Time constant for evidence accumulation for the transition from stopping to
+        walking.
+    lambda_turn : float
+        Poisson rate for turning.
+    random_seed : int
+        Random seed.
+
+    Notes
+    -----
+    See `Demir et al., 2020`_ for details.
+
     .. _Demir et al., 2020: https://doi.org/10.7554/eLife.57524
     """
 
@@ -45,55 +91,6 @@ class PlumeNavigationController:
         lambda_turn: float = 1.33,  # s^-1
         random_seed: int = 0,
     ) -> None:
-        """
-        Parameters
-        ----------
-        dt : float
-            Time step of the physics simulation in seconds.
-        forward_dn_drive : tuple[float, float]
-            Drive values for forward walking.
-        left_turn_dn_drive : tuple[float, float]
-            Drive values for left turn.
-        right_turn_dn_drive : tuple[float, float]
-            Drive values for right turn.
-        stop_dn_drive : tuple[float, float]
-            Drive values for stopping.
-        turn_duration : float
-            Duration of the turn in seconds.
-        lambda_ws_0 : float
-            Baseline rate of transition from walking to stopping.
-        delta_lambda_ws : float
-            Change in the rate of transition from walking to stopping after an
-            encounter.
-        tau_s : float
-            Time constant for the transition from walking to stopping.
-        alpha : float
-            Parameter for the sigmoid function that determines the turning direction.
-        tau_freq_conv : float
-            Time constant for the exponential kernel that convolves the encounter
-            history to determine the turning direction.
-        cumulative_evidence_window : float
-            Window size for the cumulative evidence of the encounter history. In other
-            words, encounters more than this many seconds ago are ignored.
-        lambda_sw_0 : float
-            Baseline rate of transition from stopping to walking.
-        delta_lambda_sw : float
-            Maximum change in the rate of transition from stopping to walking after an
-            encounter.
-        tau_w : float
-            Time constant for evidence accumulation for the transition from stopping to
-            walking.
-        lambda_turn : float
-            Poisson rate for turning.
-        random_seed : int
-            Random seed.
-
-        Notes
-        -----
-        See `Demir et al., 2020`_ for details.
-
-        .. _Demir et al., 2020: https://doi.org/10.7554/eLife.57524
-        """
         self.dt = dt
         # DN drives
         self.dn_drives = {

--- a/flygym/examples/olfaction/plume_tracking_task.py
+++ b/flygym/examples/olfaction/plume_tracking_task.py
@@ -22,6 +22,20 @@ class PlumeNavigationTask(HybridTurningController):
     of the API references for the detailed specifications of the action
     space, the observation space, the reward, the "terminated" and
     "truncated" flags, and the "info" dictionary.
+
+    Parameters
+    ----------
+    fly: Fly
+        The fly object to be used. See
+        ``flygym.example.locomotion.HybridTurningController``.
+    arena: OdorPlumeArena
+        The odor plume arena object to be used. Initialize it before
+        creating the ``PlumeNavigationTask`` object.
+    render_plume_alpha : float
+        The transparency of the plume overlay on the rendered images.
+    intensity_display_vmax : float
+        The maximum intensity value to be displayed on the rendered
+        images.
     """
 
     def __init__(
@@ -32,21 +46,6 @@ class PlumeNavigationTask(HybridTurningController):
         intensity_display_vmax: float = 1.0,
         **kwargs,
     ):
-        """
-        Parameters
-        ----------
-        fly: Fly
-            The fly object to be used. See
-            ``flygym.example.locomotion.HybridTurningController``.
-        arena: OdorPlumeArena
-            The odor plume arena object to be used. Initialize it before
-            creating the ``PlumeNavigationTask`` object.
-        render_plume_alpha : float
-            The transparency of the plume overlay on the rendered images.
-        intensity_display_vmax : float
-            The maximum intensity value to be displayed on the rendered
-            images.
-        """
         super().__init__(fly=fly, arena=arena, **kwargs)
         self.arena = arena
         self._plume_last_update_time = -np.inf

--- a/flygym/examples/path_integration/controller.py
+++ b/flygym/examples/path_integration/controller.py
@@ -17,6 +17,30 @@ class RandomExplorationController:
     between forward walking and turning in a Poisson process. When the fly
     turns, the turn direction is chosen randomly and the turn duration is
     drawn from a normal distribution.
+
+    Parameters
+    ----------
+    dt : float
+        Time step of the simulation.
+    forward_dn_drive : tuple[float, float], optional
+        DN drives for forward walking, by default (1.0, 1.0).
+    left_turn_dn_drive : tuple[float, float], optional
+        DN drives for turning left, by default (-0.4, 1.2).
+    right_turn_dn_drive : tuple[float, float], optional
+        DN drives for turning right, by default (1.2, -0.4).
+    turn_duration_mean : float, optional
+        Mean of the turn duration distribution in seconds, by default
+        0.4.
+    turn_duration_std : float, optional
+        Standard deviation of the turn duration distribution in
+        seconds, by default 0.1.
+    lambda_turn : float, optional
+        Rate of the Poisson process for turning, by default 1.0.
+    seed : int, optional
+        Random seed, by default 0.
+    init_time : float, optional
+        Initial time, in seconds, during which the fly walks straight,
+        by default 0.1.
     """
 
     def __init__(
@@ -31,31 +55,6 @@ class RandomExplorationController:
         seed: int = 0,
         init_time: float = 0.1,
     ) -> None:
-        """
-        Parameters
-        ----------
-        dt : float
-            Time step of the simulation.
-        forward_dn_drive : tuple[float, float], optional
-            DN drives for forward walking, by default (1.0, 1.0).
-        left_turn_dn_drive : tuple[float, float], optional
-            DN drives for turning left, by default (-0.4, 1.2).
-        right_turn_dn_drive : tuple[float, float], optional
-            DN drives for turning right, by default (1.2, -0.4).
-        turn_duration_mean : float, optional
-            Mean of the turn duration distribution in seconds, by default
-            0.4.
-        turn_duration_std : float, optional
-            Standard deviation of the turn duration distribution in
-            seconds, by default 0.1.
-        lambda_turn : float, optional
-            Rate of the Poisson process for turning, by default 1.0.
-        seed : int, optional
-            Random seed, by default 0.
-        init_time : float, optional
-            Initial time, in seconds, during which the fly walks straight,
-            by default 0.1.
-        """
         self.random_state = np.random.RandomState(seed)
         self.dt = dt
         self.init_time = init_time

--- a/flygym/examples/vision/arena.py
+++ b/flygym/examples/vision/arena.py
@@ -380,6 +380,7 @@ class MovingBarArena(Tethered):
     kwargs : dict
         Additional arguments to passed to the superclass.
     """
+
     def __init__(
         self,
         azimuth_func: Callable[[float], float],

--- a/flygym/examples/vision/arena.py
+++ b/flygym/examples/vision/arena.py
@@ -362,6 +362,24 @@ class MovingFlyArena(BaseArena):
 
 
 class MovingBarArena(Tethered):
+    """Flat or blocks terrain with a moving cylinder to simulate a
+    moving bar on a circular screen.
+
+    Parameters
+    ----------
+    azimuth_func : Callable[[float], float]
+        Function that takes time as input and returns the azimuth angle
+        of the cylinder.
+    visual_angle : tuple[float, float]
+        Width and height of the cylinder in degrees.
+    distance : float
+        Distance from the center of the arena to the center of the
+        cylinders.
+    rgba : tuple[float, float, float, float]
+        Color of the cylinder.
+    kwargs : dict
+        Additional arguments to passed to the superclass.
+    """
     def __init__(
         self,
         azimuth_func: Callable[[float], float],
@@ -370,24 +388,6 @@ class MovingBarArena(Tethered):
         rgba=(0, 0, 0, 1),
         **kwargs,
     ):
-        """Flat or blocks terrain with a moving cylinder to simulate a
-        moving bar on a circular screen.
-
-        Parameters
-        ----------
-        azimuth_func : Callable[[float], float]
-            Function that takes time as input and returns the azimuth angle
-            of the cylinder.
-        visual_angle : tuple[float, float]
-            Width and height of the cylinder in degrees.
-        distance : float
-            Distance from the center of the arena to the center of the
-            cylinders.
-        rgba : tuple[float, float, float, float]
-            Color of the cylinder.
-        kwargs : dict
-            Additional arguments to passed to the superclass.
-        """
         super().__init__(**kwargs)
 
         self.azimuth_func = azimuth_func

--- a/flygym/examples/vision/realistic_vision.py
+++ b/flygym/examples/vision/realistic_vision.py
@@ -22,17 +22,16 @@ class RealisticVisionFly(HybridTurningFly):
     of the API references for the detailed specifications of the action
     space, the observation space, the reward, the "terminated" and
     "truncated" flags, and the "info" dictionary.
+
+    Parameters
+    ----------
+    vision_network_dir : str, optional
+        Path to the directory containing the vision network checkpoint.
+        If not provided, model 000 from Lappalainen et al., 2023 will
+        be used.
     """
 
     def __init__(self, vision_network_dir=None, *args, **kwargs):
-        """
-        Parameters
-        ----------
-        vision_network_dir : str, optional
-            Path to the directory containing the vision network checkpoint.
-            If not provided, model 000 from Lappalainen et al., 2023 will
-            be used.
-        """
         super().__init__(*args, **kwargs, enable_vision=True)
         if vision_network_dir is None:
             vision_network_dir = flyvision.results_dir / "opticflow/000/0000"

--- a/flygym/examples/vision/simple_visual_taxis.py
+++ b/flygym/examples/vision/simple_visual_taxis.py
@@ -21,27 +21,26 @@ class VisualTaxis(HybridTurningController):
     of the API references for the detailed specifications of the action
     space, the observation space, the reward, the "terminated" and
     "truncated" flags, and the "info" dictionary.
+
+    Parameters
+    ----------
+    camera : Camera
+        The camera to be used for rendering.
+    obj_threshold : float
+        The threshold for object detection. Minimum and maximum
+        brightness values are 0 and 1. If an ommatidium's intensity
+        reading is below this value, then it is considered that this
+        ommatidium is seeing the object.
+    decision_interval : float
+        The interval between updates of descending drives, in seconds.
+    kwargs
+        Additional keyword arguments to be passed to
+        ``HybridTurningController.__init__``.
     """
 
     def __init__(
         self, camera: Camera, obj_threshold=0.15, decision_interval=0.05, **kwargs
     ):
-        """
-        Parameters
-        ----------
-        camera : Camera
-            The camera to be used for rendering.
-        obj_threshold : float
-            The threshold for object detection. Minimum and maximum
-            brightness values are 0 and 1. If an ommatidium's intensity
-            reading is below this value, then it is considered that this
-            ommatidium is seeing the object.
-        decision_interval : float
-            The interval between updates of descending drives, in seconds.
-        kwargs
-            Additional keyword arguments to be passed to
-            ``HybridTurningController.__init__``.
-        """
         super().__init__(cameras=[camera], **kwargs)
 
         self.obj_threshold = obj_threshold

--- a/flygym/fly.py
+++ b/flygym/fly.py
@@ -140,7 +140,7 @@ class Fly:
         in which time steps the visual inputs have been refreshed. In other
         words, the visual input frames where this mask is False are
         repetitions of the previous updated visual input frames.
-    
+
     Parameters
     ----------
     name : str, optional

--- a/flygym/fly.py
+++ b/flygym/fly.py
@@ -140,6 +140,157 @@ class Fly:
         in which time steps the visual inputs have been refreshed. In other
         words, the visual input frames where this mask is False are
         repetitions of the previous updated visual input frames.
+    
+    Parameters
+    ----------
+    name : str, optional
+        The name of the fly model. Will be automatically generated if
+        not provided.
+    actuated_joints : list[str], optional
+        List of names of actuated joints. By default all active leg
+        DoFs.
+    contact_sensor_placements : list[str], optional
+        List of body segments where contact sensors are placed. By
+        default all tarsus segments.
+    xml_variant: str or Path, optional
+        The variant of the fly model to use. Multiple variants exist
+        because when replaying experimentally recorded behavior, the
+        ordering of DoF angles in multi-DoF joints depends on how they
+        are configured in the upstream inverse kinematics program. Two
+        variants are provided: "seqik" (default) and "deepfly3d" (for
+        legacy data produced by DeepFly3D, Gunel et al., eLife, 2019).
+        The ordering of DoFs can be seen from the XML files under
+        ``flygym/data/mjcf/``.
+    spawn_pos : tuple[float, float, float], optional
+        The (x, y, z) position in the arena defining where the fly
+        will be spawn, in mm. By default (0, 0, 0.5).
+    spawn_orientation : tuple[float, float, float], optional
+        The spawn orientation of the fly in the Euler angle format:
+        (x, y, z), where x, y, z define the rotation around x, y and
+        z in radian. By default (0.0, 0.0, pi/2), which leads to a
+        position facing the positive direction of the x-axis.
+    control : str, optional
+        The joint controller type. Can be "position", "velocity", or
+        "motor", by default "position".
+    init_pose : BaseState, optional
+        Which initial pose to start the simulation from. By default
+        "stretch" kinematic pose with all legs fully stretched.
+    floor_collisions :str
+        Which set of collisions should collide with the floor. Can be
+        "all", "legs", "tarsi" or a list of body names. By default
+        "legs".
+    self_collisions : str
+        Which set of collisions should collide with each other. Can be
+        "all", "legs", "legs-no-coxa", "tarsi", "none", or a list of
+        body names. By default "legs".
+    detect_flip : bool
+        If True, the simulation will indicate whether the fly has
+        flipped in the ``info`` returned by ``.step(...)``. Flip
+        detection is achieved by checking whether the leg tips are free
+        of any contact for a duration defined in the configuration
+        file. Flip detection is disabled for a period of time at the
+        beginning of the simulation as defined in the configuration
+        file. This avoids spurious detection when the fly is not
+        standing reliably on the ground yet. By default False.
+    joint_stiffness : float
+        Stiffness of actuated joints, by default 0.05.
+        joint_stiffness : float
+        Stiffness of actuated joints, by default 0.05.
+    joint_damping : float
+        Damping coefficient of actuated joints, by default 0.06.
+    non_actuated_joint_stiffness : float
+        Stiffness of non-actuated joints, by default 1.0. If set to 0,
+        the DoF would passively drift over time. Therefore it is set
+        explicitly here for better stability.
+    non_actuated_joint_damping : float
+        Damping coefficient of non-actuated joints, by default 1.0.
+        Similar to ``non_actuated_joint_stiffness``, it is set
+        explicitly here for better stability.
+    neck_stiffness : Union[float, None]
+        Stiffness of the neck joints (``joint_Head``,
+        ``joint_Head_roll``, and ``joint_Head_yaw``), by default 10.0.
+        The head joints have their stiffness set separately, typically
+        to a higher value than the other non-actuated joints, to ensure
+        that the visual input is not perturbed by unintended passive
+        head movements. If set, this value overrides
+        ``non_actuated_joint_stiffness``.
+    actuator_gain : Union[float, list[float]]
+        Gain of the actuator:
+        If ``control`` is "position", it is the position gain of the
+        actuators.
+        If ``control`` is "velocity", it is the velocity gain of the
+        actuators.
+        If ``control`` is "motor", it is not used
+        if the actuator gain is a list, it needs to be of same length as
+        the number of actuated joints and will be applied to every joint
+    actuator_forcerange : Union[float, tuple[float, float], list]
+        The force limit of the actuators. If a single value is
+        provided, it will be symmetrically applied to all actuators
+        (-a, a). If a tuple is provided, the first value is the lower
+        limit and the second value is the upper limit. If a list is
+        provided, it should have the same length as the number of
+        actuators. By default 65.0.
+    tarsus_stiffness : float
+        Stiffness of the passive, compliant tarsus joints, by default
+        7.5.
+    tarsus_damping : float
+        Damping coefficient of the passive, compliant tarsus joints, by
+        default 1e-2.
+    friction : float
+        Sliding, torsional, and rolling friction coefficients, by
+        default (1, 0.005, 0.0001)
+    contact_solref: tuple[float, float]
+        MuJoCo contact reference parameters (see `MuJoCo documentation
+        <https://mujoco.readthedocs.io/en/stable/modeling.html#impedance>`_
+        for details). By default (9.99e-01, 9.999e-01, 1.0e-03,
+        5.0e-01, 2.0e+00). Under the default configuration, contacts
+        are very stiff. This is to avoid penetration of the leg tips
+        into the ground when leg adhesion is enabled. The user might
+        want to decrease the stiffness if the stability becomes an
+        issue.
+    contact_solimp: tuple[float, float, float, float, float]
+        MuJoCo contact reference parameters (see `MuJoCo docs
+        <https://mujoco.readthedocs.io/en/stable/modeling.html#reference>`_
+        for details). By default (9.99e-01, 9.999e-01, 1.0e-03,
+        5.0e-01, 2.0e+00). Under the default configuration, contacts
+        are very stiff. This is to avoid penetration of the leg tips
+        into the ground when leg adhesion is enabled. The user might
+        want to decrease the stiffness if the stability becomes an
+        issue.
+    enable_olfaction : bool
+        Whether to enable olfaction, by default False.
+    enable_vision : bool
+        Whether to enable vision, by default False.
+    render_raw_vision : bool
+        If ``enable_vision`` is True, whether to render the raw vision
+        (raw pixel values before binning by ommatidia), by default
+        False.
+    vision_refresh_rate : int
+        The rate at which the vision sensor is updated, in Hz, by
+        default
+        500.
+    enable_adhesion : bool
+        Whether to enable adhesion. By default False.
+    adhesion_force : float
+        The magnitude of the adhesion force. By default 20.
+    draw_adhesion : bool
+        Whether to signal that adhesion is on by changing the color of
+        the concerned leg. By default False.
+    draw_sensor_markers : bool
+        If True, colored spheres will be added to the model to indicate
+        the positions of the cameras (for vision) and odor sensors. By
+        default False.
+    neck_kp : float, optional
+        Position gain of the neck position actuators. If supplied, this
+        will overwrite ``actuator_kp`` for the neck actuators.
+        Otherwise, ``actuator_kp`` will be used.
+    head_stabilization_model : Callable or str optional
+        If callable, it should be a function that, given the observation,
+        predicts signals that need to be applied to the neck DoFs to
+        stabilizes the head of the fly. If "thorax", the rotation (roll
+        and pitch) of the thorax is inverted and applied to the head by
+        the neck actuators. If None (default), no head stabilization is
+        applied.
     """
 
     config = util.load_config()
@@ -196,159 +347,6 @@ class Fly:
         neck_kp: Optional[float] = None,
         head_stabilization_model: Optional[Union[Callable, str]] = None,
     ) -> None:
-        """Initialize a NeuroMechFly environment.
-
-        Parameters
-        ----------
-        name : str, optional
-            The name of the fly model. Will be automatically generated if
-            not provided.
-        actuated_joints : list[str], optional
-            List of names of actuated joints. By default all active leg
-            DoFs.
-        contact_sensor_placements : list[str], optional
-            List of body segments where contact sensors are placed. By
-            default all tarsus segments.
-        xml_variant: str or Path, optional
-            The variant of the fly model to use. Multiple variants exist
-            because when replaying experimentally recorded behavior, the
-            ordering of DoF angles in multi-DoF joints depends on how they
-            are configured in the upstream inverse kinematics program. Two
-            variants are provided: "seqik" (default) and "deepfly3d" (for
-            legacy data produced by DeepFly3D, Gunel et al., eLife, 2019).
-            The ordering of DoFs can be seen from the XML files under
-            ``flygym/data/mjcf/``.
-        spawn_pos : tuple[float, float, float], optional
-            The (x, y, z) position in the arena defining where the fly
-            will be spawn, in mm. By default (0, 0, 0.5).
-        spawn_orientation : tuple[float, float, float], optional
-            The spawn orientation of the fly in the Euler angle format:
-            (x, y, z), where x, y, z define the rotation around x, y and
-            z in radian. By default (0.0, 0.0, pi/2), which leads to a
-            position facing the positive direction of the x-axis.
-        control : str, optional
-            The joint controller type. Can be "position", "velocity", or
-            "motor", by default "position".
-        init_pose : BaseState, optional
-            Which initial pose to start the simulation from. By default
-            "stretch" kinematic pose with all legs fully stretched.
-        floor_collisions :str
-            Which set of collisions should collide with the floor. Can be
-            "all", "legs", "tarsi" or a list of body names. By default
-            "legs".
-        self_collisions : str
-            Which set of collisions should collide with each other. Can be
-            "all", "legs", "legs-no-coxa", "tarsi", "none", or a list of
-            body names. By default "legs".
-        detect_flip : bool
-            If True, the simulation will indicate whether the fly has
-            flipped in the ``info`` returned by ``.step(...)``. Flip
-            detection is achieved by checking whether the leg tips are free
-            of any contact for a duration defined in the configuration
-            file. Flip detection is disabled for a period of time at the
-            beginning of the simulation as defined in the configuration
-            file. This avoids spurious detection when the fly is not
-            standing reliably on the ground yet. By default False.
-        joint_stiffness : float
-            Stiffness of actuated joints, by default 0.05.
-            joint_stiffness : float
-            Stiffness of actuated joints, by default 0.05.
-        joint_damping : float
-            Damping coefficient of actuated joints, by default 0.06.
-        non_actuated_joint_stiffness : float
-            Stiffness of non-actuated joints, by default 1.0. If set to 0,
-            the DoF would passively drift over time. Therefore it is set
-            explicitly here for better stability.
-        non_actuated_joint_damping : float
-            Damping coefficient of non-actuated joints, by default 1.0.
-            Similar to ``non_actuated_joint_stiffness``, it is set
-            explicitly here for better stability.
-        neck_stiffness : Union[float, None]
-            Stiffness of the neck joints (``joint_Head``,
-            ``joint_Head_roll``, and ``joint_Head_yaw``), by default 10.0.
-            The head joints have their stiffness set separately, typically
-            to a higher value than the other non-actuated joints, to ensure
-            that the visual input is not perturbed by unintended passive
-            head movements. If set, this value overrides
-            ``non_actuated_joint_stiffness``.
-        actuator_gain : Union[float, list[float]]
-            Gain of the actuator:
-            If ``control`` is "position", it is the position gain of the
-            actuators.
-            If ``control`` is "velocity", it is the velocity gain of the
-            actuators.
-            If ``control`` is "motor", it is not used
-            if the actuator gain is a list, it needs to be of same length as
-            the number of actuated joints and will be applied to every joint
-        actuator_forcerange : Union[float, tuple[float, float], list]
-            The force limit of the actuators. If a single value is
-            provided, it will be symmetrically applied to all actuators
-            (-a, a). If a tuple is provided, the first value is the lower
-            limit and the second value is the upper limit. If a list is
-            provided, it should have the same length as the number of
-            actuators. By default 65.0.
-        tarsus_stiffness : float
-            Stiffness of the passive, compliant tarsus joints, by default
-            7.5.
-        tarsus_damping : float
-            Damping coefficient of the passive, compliant tarsus joints, by
-            default 1e-2.
-        friction : float
-            Sliding, torsional, and rolling friction coefficients, by
-            default (1, 0.005, 0.0001)
-        contact_solref: tuple[float, float]
-            MuJoCo contact reference parameters (see `MuJoCo documentation
-            <https://mujoco.readthedocs.io/en/stable/modeling.html#impedance>`_
-            for details). By default (9.99e-01, 9.999e-01, 1.0e-03,
-            5.0e-01, 2.0e+00). Under the default configuration, contacts
-            are very stiff. This is to avoid penetration of the leg tips
-            into the ground when leg adhesion is enabled. The user might
-            want to decrease the stiffness if the stability becomes an
-            issue.
-        contact_solimp: tuple[float, float, float, float, float]
-            MuJoCo contact reference parameters (see `MuJoCo docs
-            <https://mujoco.readthedocs.io/en/stable/modeling.html#reference>`_
-            for details). By default (9.99e-01, 9.999e-01, 1.0e-03,
-            5.0e-01, 2.0e+00). Under the default configuration, contacts
-            are very stiff. This is to avoid penetration of the leg tips
-            into the ground when leg adhesion is enabled. The user might
-            want to decrease the stiffness if the stability becomes an
-            issue.
-        enable_olfaction : bool
-            Whether to enable olfaction, by default False.
-        enable_vision : bool
-            Whether to enable vision, by default False.
-        render_raw_vision : bool
-            If ``enable_vision`` is True, whether to render the raw vision
-            (raw pixel values before binning by ommatidia), by default
-            False.
-        vision_refresh_rate : int
-            The rate at which the vision sensor is updated, in Hz, by
-            default
-            500.
-        enable_adhesion : bool
-            Whether to enable adhesion. By default False.
-        adhesion_force : float
-            The magnitude of the adhesion force. By default 20.
-        draw_adhesion : bool
-            Whether to signal that adhesion is on by changing the color of
-            the concerned leg. By default False.
-        draw_sensor_markers : bool
-            If True, colored spheres will be added to the model to indicate
-            the positions of the cameras (for vision) and odor sensors. By
-            default False.
-        neck_kp : float, optional
-            Position gain of the neck position actuators. If supplied, this
-            will overwrite ``actuator_kp`` for the neck actuators.
-            Otherwise, ``actuator_kp`` will be used.
-        head_stabilization_model : Callable or str optional
-            If callable, it should be a function that, given the observation,
-            predicts signals that need to be applied to the neck DoFs to
-            stabilizes the head of the fly. If "thorax", the rotation (roll
-            and pitch) of the thorax is inverted and applied to the head by
-            the neck actuators. If None (default), no head stabilization is
-            applied.
-        """
         actuated_joints = list(actuated_joints)
 
         # Check neck actuation if head stabilization is enabled

--- a/flygym/simulation.py
+++ b/flygym/simulation.py
@@ -32,7 +32,7 @@ class Simulation(gym.Env):
     physics: dm_control.mjcf.Physics
         The MuJoCo Physics object built from the arena's MJCF model with
         the fly in it.
-    
+
     Parameters
     ----------
     flies : Iterable[flygym.fly.Fly] or Fly
@@ -350,7 +350,7 @@ class SingleFlySimulation(Simulation):
     physics: dm_control.mjcf.Physics
         The MuJoCo Physics object built from the arena's MJCF model with
         the fly in it.
-    
+
     Parameters
     ----------
     fly : Fly

--- a/flygym/simulation.py
+++ b/flygym/simulation.py
@@ -32,6 +32,23 @@ class Simulation(gym.Env):
     physics: dm_control.mjcf.Physics
         The MuJoCo Physics object built from the arena's MJCF model with
         the fly in it.
+    
+    Parameters
+    ----------
+    flies : Iterable[flygym.fly.Fly] or Fly
+        List of flies in the simulation.
+    cameras : Iterable[flygym.camera.Camera] or Camera, optional
+        List of cameras in the simulation. Defaults to the left camera
+        of the first fly.
+    arena : flygym.arena.BaseArena, optional
+        The arena in which the fly is placed. ``FlatTerrain`` will be
+        used if not specified.
+    timestep : float
+        Simulation timestep in seconds, by default 0.0001.
+    gravity : tuple[float, float, float]
+        Gravity in (x, y, z) axes, by default (0., 0., -9.81e3). Note
+        that the gravity is -9.81 * 1000 due to the scaling of the
+        model.
     """
 
     def __init__(
@@ -42,24 +59,6 @@ class Simulation(gym.Env):
         timestep: float = 0.0001,
         gravity: tuple[float, float, float] = (0.0, 0.0, -9.81e3),
     ):
-        """
-        Parameters
-        ----------
-        flies : Iterable[flygym.fly.Fly] or Fly
-            List of flies in the simulation.
-        cameras : Iterable[flygym.camera.Camera] or Camera, optional
-            List of cameras in the simulation. Defaults to the left camera
-            of the first fly.
-        arena : flygym.arena.BaseArena, optional
-            The arena in which the fly is placed. ``FlatTerrain`` will be
-            used if not specified.
-        timestep : float
-            Simulation timestep in seconds, by default 0.0001.
-        gravity : tuple[float, float, float]
-            Gravity in (x, y, z) axes, by default (0., 0., -9.81e3). Note
-            that the gravity is -9.81 * 1000 due to the scaling of the
-            model.
-        """
         if isinstance(flies, Iterable):
             self.flies = list(flies)
         else:
@@ -351,6 +350,23 @@ class SingleFlySimulation(Simulation):
     physics: dm_control.mjcf.Physics
         The MuJoCo Physics object built from the arena's MJCF model with
         the fly in it.
+    
+    Parameters
+    ----------
+    fly : Fly
+        The fly in the simulation.
+    cameras : Iterable[Fly] or Camera, optional
+        List of cameras in the simulation. Defaults to the left camera
+        of the first fly.
+    arena : flygym.arena.BaseArena, optional
+        The arena in which the fly is placed. ``FlatTerrain`` will be
+        used if not specified.
+    timestep : float
+        Simulation timestep in seconds, by default 0.0001.
+    gravity : tuple[float, float, float]
+        Gravity in (x, y, z) axes, by default (0., 0., -9.81e3). Note
+        that the gravity is -9.81 * 1000 due to the scaling of the
+        model.
     """
 
     def __init__(
@@ -361,24 +377,6 @@ class SingleFlySimulation(Simulation):
         timestep: float = 0.0001,
         gravity: tuple[float, float, float] = (0.0, 0.0, -9.81e3),
     ):
-        """
-        Parameters
-        ----------
-        fly : Fly
-            The fly in the simulation.
-        cameras : Iterable[Fly] or Camera, optional
-            List of cameras in the simulation. Defaults to the left camera
-            of the first fly.
-        arena : flygym.arena.BaseArena, optional
-            The arena in which the fly is placed. ``FlatTerrain`` will be
-            used if not specified.
-        timestep : float
-            Simulation timestep in seconds, by default 0.0001.
-        gravity : tuple[float, float, float]
-            Gravity in (x, y, z) axes, by default (0., 0., -9.81e3). Note
-            that the gravity is -9.81 * 1000 due to the scaling of the
-            model.
-        """
         self.fly = fly
         super().__init__(
             flies=[fly],


### PR DESCRIPTION
### Description
1. Fix typo
2. In NumPyDoc, parameters of the `__init__` method of a class should be documented under the class docstring (see
https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring). Otherwise Sphinx doesn't build the autodoc correctly.

### Does this address any currently open issues?
No