### PR TITLE
Make fly flip detection based on cardinal direction sensing

### DIFF
--- a/flygym/config.yaml
+++ b/flygym/config.yaml
@@ -189,10 +189,6 @@ olfaction:
       rel_pos: [0.02, 0.00, -0.10]
       marker_rgba: [0.08, 0.4, 0.9, 1]
 
-flip_detection:
-  ignore_period: 0.1  # in the first N seconds (initialization period), ignore flips
-  min_flip_duration: 0.05  # ignore possible flips shorter than this
-
 paths:
   mjcf:
     deepfly3d: mjcf/neuromechfly_deepfly3d_kinorder_ryp.xml

--- a/flygym/examples/olfaction/tests/test_plume_tracking_task.py
+++ b/flygym/examples/olfaction/tests/test_plume_tracking_task.py
@@ -57,7 +57,7 @@ def test_plume_tracking_task():
         "odor_intensity",
         "cardinal_vectors",
     }
-    expected_info_keys = {"net_corrections", "joints", "adhesion"}
+    expected_info_keys = {"net_corrections", "joints", "adhesion", "flip"}
     for obs in obs_hist:
         assert set(obs.keys()) == expected_obs_keys
     for info in info_hist:

--- a/flygym/fly.py
+++ b/flygym/fly.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
@@ -378,9 +379,12 @@ class Fly:
         self.head_stabilization_model = head_stabilization_model
 
         if detect_flip:
-            raise DeprecationWarning(
-                "The `detect_flip` parameter is deprecated and will be removed in "
-                "future releases. Flips are now always detected."
+            warnings.warn(
+                (
+                    "DeprecationWarning: The `detect_flip` parameter is deprecated and "
+                    "will be removed in future releases. Flips are now always detected."
+                ),
+                DeprecationWarning,
             )
 
         # Load NMF model

--- a/flygym/tests/test_flip_detection.py
+++ b/flygym/tests/test_flip_detection.py
@@ -1,0 +1,72 @@
+import numpy as np
+import tempfile
+import logging
+from pathlib import Path
+
+from flygym import Fly, SingleFlySimulation, is_rendering_skipped
+
+
+def test_fly_flipped():
+    np.random.seed(0)
+
+    print("is_rendering_skipped: ", is_rendering_skipped)
+
+    cameras = [] if is_rendering_skipped else None  # None = default camera
+    fly = Fly(spawn_orientation=(0, np.pi, 0), spawn_pos=(0, 0, 3))
+    sim = SingleFlySimulation(fly=fly, cameras=cameras)
+    run_time = 0.02
+
+    obs, _ = sim.reset()
+    fly_init_pos = obs["joints"][0]
+
+    rendered_images = []
+    info_hist = []
+    while sim.curr_time < run_time - 1e-5:
+        action = {"joints": fly_init_pos}
+        obs, reward, terminated, truncated, info = sim.step(action)
+        img = None if is_rendering_skipped else sim.render()[0]
+        if img is not None:
+            rendered_images.append(img)
+        info_hist.append(info)
+    sim.close()
+
+    assert all([info["flip"] for info in info_hist])
+
+    temp_base_dir = Path(tempfile.gettempdir()) / "flygym_test"
+    logging.info(f"temp_base_dir: {temp_base_dir}")
+    out_dir = temp_base_dir / "fly_flip_detection"
+    if not is_rendering_skipped:
+        sim.cameras[0].save_video(out_dir / "flipped.mp4", stabilization_time=0)
+
+
+def test_fly_not_flipped():
+    np.random.seed(0)
+
+    print("is_rendering_skipped: ", is_rendering_skipped)
+
+    cameras = [] if is_rendering_skipped else None  # None = default camera
+    fly = Fly(spawn_orientation=(0, 0, 0), spawn_pos=(0, 0, 3))
+    sim = SingleFlySimulation(fly=fly, cameras=cameras)
+    run_time = 0.05
+
+    obs, _ = sim.reset()
+    fly_init_pos = obs["joints"][0]
+
+    rendered_images = []
+    info_hist = []
+    while sim.curr_time < run_time - 1e-5:
+        action = {"joints": fly_init_pos}
+        obs, reward, terminated, truncated, info = sim.step(action)
+        img = None if is_rendering_skipped else sim.render()[0]
+        if img is not None:
+            rendered_images.append(img)
+        info_hist.append(info)
+    sim.close()
+
+    assert all([not info["flip"] for info in info_hist])
+
+    temp_base_dir = Path(tempfile.gettempdir()) / "flygym_test"
+    logging.info(f"temp_base_dir: {temp_base_dir}")
+    out_dir = temp_base_dir / "fly_flip_detection"
+    if not is_rendering_skipped:
+        sim.cameras[0].save_video(out_dir / "not_flipped.mp4", stabilization_time=0)


### PR DESCRIPTION
### Description
Previously, flipping is detected by checking whether all legs have been out of ground contact for a period of time.

Now that cardinal direction sensing is working great (#219), we detect flips by checking whether the z component of the "up" cardinal vector is negative.

Also, I'm deprecating the `detect_flip` parameter of `Fly.__init__`. Flips are always detected since the computation is very light.

### Does this address any currently open issues?
[list open issues here]