### PR TITLE
VSCode devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-bookworm
+
+ARG USERNAME=flygym
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install system dependencies
+RUN apt update && \
+    apt-get install -y libegl1-mesa-dev ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set renderer
+ENV MUJOCO_GL=egl
+ENV PYOPENGL_PLATFORM=egl
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "flygym_environment",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "donjayamanne.python-extension-pack"
+            ],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "bash"
+                    }
+                }
+            }
+        }
+    },
+    "mounts": [
+        "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
+    ],
+    "containerEnv": {
+        "DISPLAY": "${localEnv:DISPLAY}"
+    },    
+    "postCreateCommand": "pip install \"flyvision @ https://github.com/Nely-EPFL/flyvis/archive/refs/heads/main.zip\" && pip install -e \".[examples,dev]\" --no-warn-script-location",
+    "runArgs": [
+        "--device=/dev/dri"
+    ]
+}


### PR DESCRIPTION
### Description
VSCode's [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) feature allows to simplify the development environment setup. All the required configs are stored in the repo itself. All you need to do is to:

1. Open the project folder in VSCode.  
2. Install the "Dev containers" extension (you will be prompted automatically).
3. Reopen the project in a container (you will be prompted, or use "Dev Containers: Reopen in Container" command from the Command Palette)
4. Wait a few minutes for the dev container to be generated.

The current version should provide the same development environment on all modern Linux systems, it uses python:3.12-bookworm, just like the current CI image.
In theory it should work on Windows with WSL and MacOS. Probably some additional setup is required in order to forward X11 graphics, and maybe other OS level stuff.

### Does this address any currently open issues?
No