### PR TITLE
Python v3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "dm_control==1.0.27",
     # dm-tree 0.1.9 fails to install on macOS as of now, see #128 on its repo
     "dm_tree==0.1.8",
-    "numba==0.60.0",
+    "numba==0.61.2",
     "opencv-python>=4.0,<5.0",
 ]
 


### PR DESCRIPTION
Fixes #248

Seems like it won't be completely straightforward so I'll make a separate branch so as not to break dev while working on this.

Currently it looks like there isn't a prebuilt dm_tree wheel that supports python3.13, so pip tries to build from source and then I get an error that I don't have bazel installed while building labmaze.