### PR TITLE
Fix: Package spotlight_data/assets to fix missing spotlight_behavior_clip.npz

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023-2026 The NeuroMechFly v2 Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,4 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 flygym = ["assets/**"]
+flygym_demo = ["spotlight_data/assets/**"]


### PR DESCRIPTION
The tutorial https://neuromechfly.org/tutorials/2_replaying_experimental_recordings/ currently results in an error

`FileNotFoundError: [Errno 2] No such file or directory: '.venv/lib/python3.12/site-packages/flygym_demo/spotlight_data/assets/spotlight_behavior_clip.npz'`

This change adds spotlight_behavior_clip.npz to the build


## Before

```bash
uv build
python -m zipfile --list dist/flygym-2.0.0-py3-none-any.whl | grep .npz
# Nothing

# Files present before
python -m zipfile --list dist/flygym-2.0.0-py3-none-any.whl | wc -l
111
du -sh ./dist/flygym-2.0.0-py3-none-any.whl
8.4M	./dist/flygym-2.0.0-py3-none-any.whl
```

## After

```bash
uv build
python -m zipfile --list dist/flygym-2.0.0-py3-none-any.whl | grep .npz
flygym_demo/spotlight_data/assets/spotlight_behavior_clip.npz 2026-04-16 06:25:14       528912

# Ensuring Only 1 file added
python -m zipfile --list dist/flygym-2.0.0-py3-none-any.whl | wc -l
112
du -sh ./dist/flygym-2.0.0-py3-none-any.whl
8.9M	./dist/flygym-2.0.0-py3-none-any.whl
```

```python
from flygym_demo.spotlight_data import MotionSnippet
snippet = MotionSnippet() # Now works
```