### PR TITLE
Improve self-occlusion avoidance during eye rendering and improve GL resource management

### DIFF
--- a/src/flygym/compose/fly.py
+++ b/src/flygym/compose/fly.py
@@ -478,6 +478,8 @@ class Fly(BaseCompositionElement):
                 size=[0.06],
                 rgba=sensor_info["marker_rgba"],
                 mass=0,
+                contype=0,
+                conaffinity=0,
                 group=geom_group,
             )
 

--- a/src/flygym/compose/fly.py
+++ b/src/flygym/compose/fly.py
@@ -162,7 +162,6 @@ class Fly(BaseCompositionElement):
         self.sensorname_to_mjcfsensor = {}
         self.cameraname_to_mjcfcamera = {}
         self.eyecameraname_to_mjcfcamera = {}
-        self.hidden_geoms = []
 
         self.jointdof_to_neutralangle = {}
         self.jointdof_to_neutralaction_by_type = {ty: {} for ty in ActuatorType}
@@ -462,22 +461,29 @@ class Fly(BaseCompositionElement):
                 euler=sensor_info["orientation"],
                 fovy=info["fovy_per_eye"],
             )
-            if draw_sensor_markers:
-                geom = sensor_body.add(
-                    "geom",
-                    name=f"{sensor_name}_marker",
-                    type="sphere",
-                    size=[0.06],
-                    rgba=sensor_info["marker_rgba"],
-                    mass=0,
-                )
-                self.hidden_geoms.append(geom)
+
+            # Add visual markers indicating where they eye sensors are
+            # The MuJoCo renderer by default renders geoms of groups 0, 1, 2.
+            # By convention, group 0 is for main visual/collision bodies, group 1 is for
+            # helper/mocap geoms, and group 2 is for debug geoms. So if the user wants
+            # to draw sensor markers, we put them in group 1. Among the groups that are
+            # invisible by default, group 3 is often used for simplified physics geoms,
+            # and group 4 is often for additional stuff. So if the user doesn't want to
+            # draw sensor markers, we put them in group 4.
+            geom_group = 1 if draw_sensor_markers else 4
+            sensor_body.add(
+                "geom",
+                name=f"{sensor_name}_marker",
+                type="sphere",
+                size=[0.06],
+                rgba=sensor_info["marker_rgba"],
+                mass=0,
+                group=geom_group,
+            )
+
             return_dict[sensor_name] = cam
 
         self.eyecameraname_to_mjcfcamera.update(return_dict)
-
-        for segment_name in info["hidden_segments"]:
-            self.hidden_geoms.append(self.mjcf_root.find("geom", segment_name))
 
     def colorize(
         self, visuals_config_path: PathLike = DEFAULT_VISUALS_CONFIG_PATH
@@ -588,11 +594,17 @@ class Fly(BaseCompositionElement):
         with open(rigging_config_path) as f:
             rigging_config = yaml.safe_load(f)
 
+        # Load vision config to find out which geoms should be invisible to the eye
+        # cameras to avoid occlusion (e.g., the eye geoms themselves)
+        with open(assets_dir / "model/vision.yaml") as f:
+            info = yaml.safe_load(f)
+
         # Add root body and geom
         body, geom = self._add_one_body_and_geom(
             self.mjcf_root.worldbody,
             self.root_segment,
             rigging_config[self.root_segment.name],
+            geom_group=0,
         )
         self.bodyseg_to_mjcfbody[self.root_segment] = body
         self.bodyseg_to_mjcfgeom[self.root_segment] = geom
@@ -614,8 +626,19 @@ class Fly(BaseCompositionElement):
                 raise FlyGymInternalError(
                     f"Missing rigging config for body segment {jointdof.child.name}"
                 )
+
+            # If the geom should be invisible to eye cameras, we put it in group 2.
+            # Otherwise, it goes in group 0. The MuJoCo render renders geoms in groups
+            # 0, 1, 2 by default, so a default renderer renders all body geoms, but the
+            # eye cameras can be configured to ignore group 2 geoms to avoid visual
+            # occlusion. This makes the behavior of FlyGym less surprising to users who
+            # wish to add their own renderes manually. We avoid group 1 becasue it's by
+            # convention meant for mocap markers and helper geoms.
+            geom_group = 2 if jointdof.child.name in info["hidden_segments"] else 0
+
+            # Actually add the body and geom to the MJCF model
             body, geom = self._add_one_body_and_geom(
-                parent_body, jointdof.child, my_rigging_config
+                parent_body, jointdof.child, my_rigging_config, geom_group
             )
             self.bodyseg_to_mjcfbody[jointdof.child] = body
             self.bodyseg_to_mjcfgeom[jointdof.child] = geom
@@ -632,6 +655,7 @@ class Fly(BaseCompositionElement):
         parent_body: mjcf.Element,
         segment: BodySegment,
         my_rigging_config: dict[str, Any],
+        geom_group: int,
     ) -> tuple[mjcf.Element, mjcf.Element]:
         body_element = parent_body.add(
             "body",
@@ -647,6 +671,7 @@ class Fly(BaseCompositionElement):
             mass=my_rigging_config["mass"],
             contype=0,  # contact pairs to be added explicitly later
             conaffinity=0,  # contact pairs to be added explicitly later
+            group=geom_group,
         )
         return body_element, geom_element
 

--- a/src/flygym/compose/fly.py
+++ b/src/flygym/compose/fly.py
@@ -462,7 +462,7 @@ class Fly(BaseCompositionElement):
                 fovy=info["fovy_per_eye"],
             )
 
-            # Add visual markers indicating where they eye sensors are
+            # Add visual markers indicating where the eye sensors are
             # The MuJoCo renderer by default renders geoms of groups 0, 1, 2.
             # By convention, group 0 is for main visual/collision bodies, group 1 is for
             # helper/mocap geoms, and group 2 is for debug geoms. So if the user wants
@@ -599,12 +599,15 @@ class Fly(BaseCompositionElement):
         with open(assets_dir / "model/vision.yaml") as f:
             info = yaml.safe_load(f)
 
-        # Add root body and geom
+        # Add root body and geom. The root can also be hidden from eye cameras if
+        # requested in the vision config, so we apply the same group assignment rule
+        # used for all other body segments.
+        root_geom_group = 2 if self.root_segment.name in info["hidden_segments"] else 0
         body, geom = self._add_one_body_and_geom(
             self.mjcf_root.worldbody,
             self.root_segment,
             rigging_config[self.root_segment.name],
-            geom_group=0,
+            geom_group=root_geom_group,
         )
         self.bodyseg_to_mjcfbody[self.root_segment] = body
         self.bodyseg_to_mjcfgeom[self.root_segment] = geom
@@ -628,11 +631,11 @@ class Fly(BaseCompositionElement):
                 )
 
             # If the geom should be invisible to eye cameras, we put it in group 2.
-            # Otherwise, it goes in group 0. The MuJoCo render renders geoms in groups
+            # Otherwise, it goes in group 0. The MuJoCo renderer renders geoms in groups
             # 0, 1, 2 by default, so a default renderer renders all body geoms, but the
             # eye cameras can be configured to ignore group 2 geoms to avoid visual
             # occlusion. This makes the behavior of FlyGym less surprising to users who
-            # wish to add their own renderes manually. We avoid group 1 becasue it's by
+            # wish to add their own renderers manually. We avoid group 1 because it's by
             # convention meant for mocap markers and helper geoms.
             geom_group = 2 if jointdof.child.name in info["hidden_segments"] else 0
 

--- a/src/flygym/simulation.py
+++ b/src/flygym/simulation.py
@@ -338,8 +338,10 @@ class Simulation:
             )
             # Make eye render apply option to ignore geoms in group 2, which includes
             # body segments that should not be rendered by the eye cameras to avoid
-            # self-occlusion.
+            # self-occlusion. Disable group 1 as well because markers for eye positions
+            # belong to group 1.
             self.eye_renderer_scene_option = mj.MjvOption()
+            self.eye_renderer_scene_option.geomgroup[1] = 1
             self.eye_renderer_scene_option.geomgroup[2] = 0
 
         # Render each eye camera and apply fisheye correction
@@ -594,4 +596,5 @@ class Simulation:
 
         # Clear references to help GC and make close idempotent
         self.renderer = None
+        self.retina = None
         self.eye_renderer = None

--- a/src/flygym/simulation.py
+++ b/src/flygym/simulation.py
@@ -331,17 +331,18 @@ class Simulation:
 
             self.retina = Retina()
 
+        if self.eye_renderer is None:
             self.eye_renderer = mj.Renderer(
                 self.mj_model,
                 height=self.retina.nrows,
                 width=self.retina.ncols,
             )
-            # Make eye render apply option to ignore geoms in group 2, which includes
+            # Make eye renderer apply option to ignore geoms in group 2, which includes
             # body segments that should not be rendered by the eye cameras to avoid
             # self-occlusion. Disable group 1 as well because markers for eye positions
             # belong to group 1.
             self.eye_renderer_scene_option = mj.MjvOption()
-            self.eye_renderer_scene_option.geomgroup[1] = 1
+            self.eye_renderer_scene_option.geomgroup[1] = 0
             self.eye_renderer_scene_option.geomgroup[2] = 0
 
         # Render each eye camera and apply fisheye correction
@@ -596,5 +597,6 @@ class Simulation:
 
         # Clear references to help GC and make close idempotent
         self.renderer = None
-        self.retina = None
         self.eye_renderer = None
+        # Don't destruct self.retina and self.eye_renderer_scene_option: they can be
+        # reused and retina init requires some IO ops.

--- a/src/flygym/simulation.py
+++ b/src/flygym/simulation.py
@@ -50,7 +50,6 @@ class Simulation:
         self._map_internal_groundcontactsensor_ids()
         self._map_internal_site_ids()
         self._map_internal_eye_camera_ids()
-        self._map_internal_hidden_geom_ids()
 
         self.eye_renderer = None
         self.retina = None
@@ -69,6 +68,10 @@ class Simulation:
         # Reset renderers
         if self.renderer is not None:
             self.renderer.reset()
+        # Rebuild eye renderer only if it's been set up before (if the user never
+        # queried visual input, then there's no visual renderer to reset to start with)
+        if self.eye_renderer is not None:
+            self._set_up_eye_renderer()  # destruction logic is in this setup method
 
         # Stuff for performance profiling
         self._curr_step = 0
@@ -212,9 +215,7 @@ class Simulation:
         internal_ids = self._intern_actuatorids_by_type_by_fly[actuator_type][fly_name]
         return self.mj_data.actuator_force[internal_ids]
 
-    def get_ground_contact_info(
-        self, fly_name: str
-    ) -> tuple[
+    def get_ground_contact_info(self, fly_name: str) -> tuple[
         Float[np.ndarray, "6"],  # contact/no contact flag
         Float[np.ndarray, "6 3"],  # force (in contact frame)
         Float[np.ndarray, "6 3"],  # torque (in contact frame)
@@ -305,6 +306,20 @@ class Simulation:
     def get_raw_vision(
         self, fly_name: str
     ) -> list[Float[np.ndarray, "height width 3"]]:
+        """Render the fly's eye cameras and return fisheye-corrected frames.
+
+        Certain body parts are invisible to the eye cameras to avoid self-occlusion, as
+        configured in `flygym/assets/model/vision.yaml`. These geoms are assigned to
+        geom group 2, which _is_ rendered by the MuJoCo render by default, but the eye
+        render within FlyGym is configured to ignore this geom group.
+
+        Args:
+            fly_name: Name of the fly to query.
+
+        Returns:
+            A list of two RGB images, one per eye camera, each with shape
+            ``(height, width, 3)`` and dtype ``uint8``.
+        """
         try:
             internal_eye_camera_ids = self._intern_eye_camera_ids_by_fly[fly_name]
         except KeyError:
@@ -313,37 +328,33 @@ class Simulation:
                 "Make sure to call fly.add_vision() when constructing the fly."
             )
 
-        internal_hidden_geom_ids = self._intern_hidden_geom_ids_by_fly.get(fly_name, [])
-        alpha = self.mj_model.geom_rgba[internal_hidden_geom_ids, 3].copy()
-        # Hide hidden geoms by setting alpha to 0
-        self.mj_model.geom_rgba[internal_hidden_geom_ids, 3] = 0
-        frames = []
-
-        if self.retina is None:
-            from flygym.vision.retina import Retina
-
-            self.retina = Retina()
-
+        # Lazy-construct Retina and eye renderer only if user queries visual input
         if self.eye_renderer is None:
-            self.eye_renderer = mj.Renderer(
-                self.mj_model,
-                height=self.retina.nrows,
-                width=self.retina.ncols,
-            )
+            self._set_up_eye_renderer()
 
+        # Render each eye camera and apply fisheye correction
+        frames = []
         for cam_id in internal_eye_camera_ids:
-            self.eye_renderer.update_scene(self.mj_data, cam_id)
+            self.eye_renderer.update_scene(
+                self.mj_data, cam_id, scene_option=self.eye_renderer_scene_option
+            )
             raw_frame = self.eye_renderer.render()
             fish_img = self.retina.correct_fisheye(raw_frame)
             frames.append(fish_img)
-
-        # # Restore original alpha values
-        self.mj_model.geom_rgba[internal_hidden_geom_ids, 3] = alpha
         return frames
 
     def get_ommatidia_readouts(
         self, fly_name: str
     ) -> Float[np.ndarray, "n_cameras n_ommatidia 2"]:
+        """Convert the rendered eye frames into ommatidia readouts.
+
+        Args:
+            fly_name: Name of the fly to query.
+
+        Returns:
+            A float32 array with shape ``(n_cameras, n_ommatidia, 2)`` containing
+            the pale/yellow channel readings for each eye camera.
+        """
         raw_vision = self.get_raw_vision(fly_name)
         ommatidia_readouts = np.array(
             [self.retina.raw_image_to_hex_pxls(image) for image in raw_vision],
@@ -520,24 +531,26 @@ class Simulation:
             for k, v in internal_eye_camera_ids_by_fly.items()
         }
 
-    def _map_internal_hidden_geom_ids(self):
-        internal_hidden_geom_ids_by_fly = defaultdict(list)
+    def _set_up_eye_renderer(self):
+        if self.retina is None:
+            from flygym.vision.retina import Retina
 
-        for fly_name, fly in self.world.fly_lookup.items():
-            for hidden_geom in fly.hidden_geoms:
-                internal_hidden_geom_id = mj.mj_name2id(
-                    self.mj_model,
-                    mj.mjtObj.mjOBJ_GEOM,
-                    hidden_geom.full_identifier,
-                )
-                internal_hidden_geom_ids_by_fly[fly_name].append(
-                    internal_hidden_geom_id
-                )
+            self.retina = Retina()
 
-        self._intern_hidden_geom_ids_by_fly = {
-            k: np.array(v, dtype=np.int32)
-            for k, v in internal_hidden_geom_ids_by_fly.items()
-        }
+        if self.eye_renderer is not None:
+            self.eye_renderer.close()
+            self.eye_renderer = None
+
+        self.eye_renderer = mj.Renderer(
+            self.mj_model,
+            height=self.retina.nrows,
+            width=self.retina.ncols,
+        )
+        # Make eye render apply option to ignore geoms in group 2, which includes
+        # body segments that should not be rendered by the eye cameras to avoid
+        # self-occlusion.
+        self.eye_renderer_scene_option = mj.MjvOption()
+        self.eye_renderer_scene_option.geomgroup[2] = 0
 
     @property
     def time(self) -> float:
@@ -570,3 +583,23 @@ class Simulation:
     def timestep(self) -> float:
         """Simulation timestep in seconds."""
         return self.mj_model.opt.timestep
+
+    def close(self):
+        # Use getattr to handle cases where attributes may not exist
+        renderer = getattr(self, "renderer", None)
+        if renderer is not None:
+            renderer.close()
+        eye_renderer = getattr(self, "eye_renderer", None)
+        if eye_renderer is not None:
+            eye_renderer.close()
+
+        # Clear references to help GC and make close idempotent
+        self.renderer = None
+        self.eye_renderer = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            # Never raise in __del__
+            pass

--- a/src/flygym/simulation.py
+++ b/src/flygym/simulation.py
@@ -68,10 +68,8 @@ class Simulation:
         # Reset renderers
         if self.renderer is not None:
             self.renderer.reset()
-        # Rebuild eye renderer only if it's been set up before (if the user never
-        # queried visual input, then there's no visual renderer to reset to start with)
-        if self.eye_renderer is not None:
-            self._set_up_eye_renderer()  # destruction logic is in this setup method
+        # The eye renderer doesn't have to be reset as it's stateless (it's the plain
+        # MuJoCo renderer, not our flygym.rendering.Renderer)
 
         # Stuff for performance profiling
         self._curr_step = 0
@@ -308,8 +306,8 @@ class Simulation:
 
         Certain body parts are invisible to the eye cameras to avoid self-occlusion, as
         configured in `flygym/assets/model/vision.yaml`. These geoms are assigned to
-        geom group 2, which _is_ rendered by the MuJoCo render by default, but the eye
-        render within FlyGym is configured to ignore this geom group.
+        geom group 2, which _is_ rendered by the MuJoCo renderer by default, but the eye
+        renderer within FlyGym is configured to ignore this geom group.
 
         Args:
             fly_name: Name of the fly to query.
@@ -328,8 +326,21 @@ class Simulation:
             )
 
         # Lazy-construct Retina and eye renderer only if user queries visual input
-        if self.eye_renderer is None:
-            self._set_up_eye_renderer()
+        if self.retina is None:
+            from flygym.vision.retina import Retina
+
+            self.retina = Retina()
+
+            self.eye_renderer = mj.Renderer(
+                self.mj_model,
+                height=self.retina.nrows,
+                width=self.retina.ncols,
+            )
+            # Make eye render apply option to ignore geoms in group 2, which includes
+            # body segments that should not be rendered by the eye cameras to avoid
+            # self-occlusion.
+            self.eye_renderer_scene_option = mj.MjvOption()
+            self.eye_renderer_scene_option.geomgroup[2] = 0
 
         # Render each eye camera and apply fisheye correction
         frames = []
@@ -535,27 +546,6 @@ class Simulation:
             for k, v in internal_eye_camera_ids_by_fly.items()
         }
 
-    def _set_up_eye_renderer(self):
-        if self.retina is None:
-            from flygym.vision.retina import Retina
-
-            self.retina = Retina()
-
-        if self.eye_renderer is not None:
-            self.eye_renderer.close()
-            self.eye_renderer = None
-
-        self.eye_renderer = mj.Renderer(
-            self.mj_model,
-            height=self.retina.nrows,
-            width=self.retina.ncols,
-        )
-        # Make eye render apply option to ignore geoms in group 2, which includes
-        # body segments that should not be rendered by the eye cameras to avoid
-        # self-occlusion.
-        self.eye_renderer_scene_option = mj.MjvOption()
-        self.eye_renderer_scene_option.geomgroup[2] = 0
-
     @property
     def time(self) -> float:
         """Current simulation time in seconds."""
@@ -589,6 +579,11 @@ class Simulation:
         return self.mj_model.opt.timestep
 
     def close(self):
+        """Clean up resources allocated by the simulation.
+
+        This method is idempotent (safe to call multiple times).
+        """
+
         # Use getattr to handle cases where attributes may not exist
         renderer = getattr(self, "renderer", None)
         if renderer is not None:
@@ -600,10 +595,3 @@ class Simulation:
         # Clear references to help GC and make close idempotent
         self.renderer = None
         self.eye_renderer = None
-
-    def __del__(self):
-        try:
-            self.close()
-        except Exception:
-            # Never raise in __del__
-            pass

--- a/src/flygym/simulation.py
+++ b/src/flygym/simulation.py
@@ -303,9 +303,7 @@ class Simulation:
             )
         self.mj_data.ctrl[internal_ids] = leg_to_adhesion_state
 
-    def get_raw_vision(
-        self, fly_name: str
-    ) -> list[Float[np.ndarray, "height width 3"]]:
+    def get_raw_vision(self, fly_name: str) -> Float[np.ndarray, "2 height width 3"]:
         """Render the fly's eye cameras and return fisheye-corrected frames.
 
         Certain body parts are invisible to the eye cameras to avoid self-occlusion, as
@@ -317,8 +315,9 @@ class Simulation:
             fly_name: Name of the fly to query.
 
         Returns:
-            A list of two RGB images, one per eye camera, each with shape
-            ``(height, width, 3)`` and dtype ``uint8``.
+            An array of shape (2, height, width, 3) containing the RGB images from the
+            fly's two eyes. The first dimension corresponds to the left and right eye,
+            in that order.
         """
         try:
             internal_eye_camera_ids = self._intern_eye_camera_ids_by_fly[fly_name]
@@ -341,7 +340,7 @@ class Simulation:
             raw_frame = self.eye_renderer.render()
             fish_img = self.retina.correct_fisheye(raw_frame)
             frames.append(fish_img)
-        return frames
+        return np.array(frames)
 
     def get_ommatidia_readouts(
         self, fly_name: str
@@ -352,8 +351,13 @@ class Simulation:
             fly_name: Name of the fly to query.
 
         Returns:
-            A float32 array with shape ``(n_cameras, n_ommatidia, 2)`` containing
-            the pale/yellow channel readings for each eye camera.
+            A float32 array with shape ``(2, n_ommatidia, 2)`` containing
+            the pale/yellow channel readings for each eye camera. The first dimension
+            corresponds to the left and right eyes, in that order). The last
+            dimension corresponds to the yellow- and pale-type ommatidia, in that
+            order. Zero values indicate that the ommatidium is of the other type.
+            For example, if `readouts[0, 5, 0]` is 0, it means that the 5th ommatidium
+            is of pale type, and the user should look at `readouts[0, 5, 1]` instead.
         """
         raw_vision = self.get_raw_vision(fly_name)
         ommatidia_readouts = np.array(

--- a/src/flygym/vision/retina.py
+++ b/src/flygym/vision/retina.py
@@ -122,7 +122,7 @@ class Retina:
         np.ndarray
             Our simulation of what the fly might see through its compound
             eyes. It is a (N, 2) array where the first dimension is for the
-            N ommatidia, and the third dimension is for the two channels.
+            N ommatidia, and the second dimension is for the two channels.
         """
         return self._raw_image_to_hex_pxls(
             raw_img,
@@ -228,8 +228,8 @@ class Retina:
         hex_id_map_flat = ommatidia_id_map.ravel()
         for i in nb.prange(hex_id_map_flat.size):
             hex_pxl_id = hex_id_map_flat[i] - 1
-            hex_pxl_size = num_pixels_per_ommatidia[hex_pxl_id]  # num raw pxls
             if hex_pxl_id != -1:
+                hex_pxl_size = num_pixels_per_ommatidia[hex_pxl_id]  # num raw pxls
                 ch_idx = pale_type_mask[hex_pxl_id]
                 vals[hex_pxl_id, ch_idx] += img_arr_flat[i, ch_idx + 1] / hex_pxl_size
         return vals / 255

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -422,20 +422,6 @@ class TestSimulationCloseMethods:
         assert dummy_a.closed is True
         assert dummy_b.closed is True
 
-    def test___del___calls_close(self, simulation):
-        class _DummyRenderer:
-            def __init__(self):
-                self.closed = False
-
-            def close(self):
-                self.closed = True
-
-        dummy = _DummyRenderer()
-        simulation.renderer = dummy
-        # call destructor helper directly (don't rely on GC timing)
-        simulation.__del__()
-        assert dummy.closed is True
-
 
 # ==============================================================================
 # set_renderer

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -410,15 +410,18 @@ class TestSimulationCloseMethods:
 
         dummy_a = _DummyRenderer()
         dummy_b = _DummyRenderer()
-        simulation.renderer = dummy_a
-        simulation.eye_renderer = dummy_b
+        # Use a fresh Simulation so this mutation cannot leak into other tests that
+        # share the module-scoped fixture instance.
+        fresh_simulation = Simulation(simulation.world)
+        fresh_simulation.renderer = dummy_a
+        fresh_simulation.eye_renderer = dummy_b
 
-        simulation.close()
+        fresh_simulation.close()
         assert dummy_a.closed is True
         assert dummy_b.closed is True
 
         # calling again should not raise and should leave state unchanged
-        simulation.close()
+        fresh_simulation.close()
         assert dummy_a.closed is True
         assert dummy_b.closed is True
 

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -392,6 +392,51 @@ class TestProfilingMethods:
         assert "Physics" in captured.out
 
 
+class TestSimulationCloseMethods:
+    def test_close_no_renderers_is_noop(self, simulation):
+        # simulation fixture should have no renderers by default
+        assert simulation.renderer is None
+        assert simulation.eye_renderer is None
+        # calling close should be a no-op and not raise
+        simulation.close()
+
+    def test_close_closes_both_renderers_and_is_idempotent(self, simulation):
+        class _DummyRenderer:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        dummy_a = _DummyRenderer()
+        dummy_b = _DummyRenderer()
+        simulation.renderer = dummy_a
+        simulation.eye_renderer = dummy_b
+
+        simulation.close()
+        assert dummy_a.closed is True
+        assert dummy_b.closed is True
+
+        # calling again should not raise and should leave state unchanged
+        simulation.close()
+        assert dummy_a.closed is True
+        assert dummy_b.closed is True
+
+    def test___del___calls_close(self, simulation):
+        class _DummyRenderer:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        dummy = _DummyRenderer()
+        simulation.renderer = dummy
+        # call destructor helper directly (don't rely on GC timing)
+        simulation.__del__()
+        assert dummy.closed is True
+
+
 # ==============================================================================
 # set_renderer
 # ==============================================================================

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -394,11 +394,14 @@ class TestProfilingMethods:
 
 class TestSimulationCloseMethods:
     def test_close_no_renderers_is_noop(self, simulation):
-        # simulation fixture should have no renderers by default
-        assert simulation.renderer is None
-        assert simulation.eye_renderer is None
+        # Use a fresh Simulation so this mutation cannot leak into other tests that
+        # share the module-scoped fixture instance.
+        fresh_simulation = Simulation(simulation.world)
+        # fresh simulation should have no renderers by default
+        assert fresh_simulation.renderer is None
+        assert fresh_simulation.eye_renderer is None
         # calling close should be a no-op and not raise
-        simulation.close()
+        fresh_simulation.close()
 
     def test_close_closes_both_renderers_and_is_idempotent(self, simulation):
         class _DummyRenderer:

--- a/tests/core/test_vision.py
+++ b/tests/core/test_vision.py
@@ -229,7 +229,7 @@ class TestFlyAddVision:
         for segname in vision_config["hidden_segments"]:
             geom_id = mj.mj_name2id(mj_model, mj.mjtObj.mjOBJ_GEOM, segname)
             assert geom_id >= 0
-            expected_group = 0 if segname == "c_thorax" else 2
+            expected_group = 2
             assert mj_model.geom_group[geom_id] == expected_group
 
     def test_markers_added_when_requested(self, vision_config):
@@ -359,10 +359,13 @@ class TestSimulationVisionIDMapping:
     ),
 )
 class TestSimulationGetRawVision:
-    def test_returns_two_frames(self, simulation_with_vision, fly_with_vision):
+    def test_returns_shape_and_type(self, simulation_with_vision, fly_with_vision):
         frames = simulation_with_vision.get_raw_vision(fly_with_vision.name)
-        assert isinstance(frames, list)
-        assert len(frames) == 2
+        assert isinstance(frames, np.ndarray)
+        assert frames.ndim == 4  # (n_cams, height, width, channels)
+        assert frames.shape[0] == 2  # two eye cameras
+        assert frames.shape[3] == 3  # RGB channels
+        assert frames.dtype == np.uint8
 
     def test_frame_shape_matches_retina(self, simulation_with_vision, fly_with_vision):
         frames = simulation_with_vision.get_raw_vision(fly_with_vision.name)
@@ -380,14 +383,6 @@ class TestSimulationGetRawVision:
         simulation_with_vision.get_raw_vision(fly_with_vision.name)
         assert simulation_with_vision.retina is not None
         assert simulation_with_vision.eye_renderer is not None
-
-    def test_hidden_geom_alpha_restored(self, simulation_with_vision, fly_with_vision):
-        """get_raw_vision should keep the scene-option state stable across renders."""
-        before = simulation_with_vision.eye_renderer_scene_option.geomgroup.copy()
-        simulation_with_vision.get_raw_vision(fly_with_vision.name)
-        after = simulation_with_vision.eye_renderer_scene_option.geomgroup
-        np.testing.assert_array_equal(before, after)
-        assert after[2] == 0
 
 
 @pytest.mark.skipif(

--- a/tests/core/test_vision.py
+++ b/tests/core/test_vision.py
@@ -4,6 +4,7 @@ import platform
 
 import pytest
 import numpy as np
+import mujoco as mj
 import yaml
 
 from flygym import assets_dir
@@ -210,25 +211,36 @@ class TestFlyAddVision:
         fly.add_vision()
         assert set(fly.eyecameraname_to_mjcfcamera.keys()) == {"l_eye_cam", "r_eye_cam"}
 
-    def test_no_markers_by_default(self, vision_config):
-        """With draw_sensor_markers=False, only the hidden body segments are added
-        to hidden_geoms — no marker spheres."""
+    def test_markers_hidden_by_default(self, vision_config):
+        """With draw_sensor_markers=False, marker geoms stay in the hidden group."""
         fly = Fly(name="vision_fly_nomarkers")
         fly.add_vision(draw_sensor_markers=False)
-        assert len(fly.hidden_geoms) == len(vision_config["hidden_segments"])
+        mj_model, _ = fly.compile()
+        for sensor_name in vision_config["sensors"]:
+            marker_name = f"{sensor_name}_marker"
+            marker_id = mj.mj_name2id(mj_model, mj.mjtObj.mjOBJ_GEOM, marker_name)
+            assert marker_id >= 0
+            assert mj_model.geom_group[marker_id] == 4
+
+    def test_hidden_segments_use_expected_groups(self, vision_config):
+        fly = Fly(name="vision_fly_hidden_groups")
+        fly.add_vision(draw_sensor_markers=False)
+        mj_model, _ = fly.compile()
+        for segname in vision_config["hidden_segments"]:
+            geom_id = mj.mj_name2id(mj_model, mj.mjtObj.mjOBJ_GEOM, segname)
+            assert geom_id >= 0
+            expected_group = 0 if segname == "c_thorax" else 2
+            assert mj_model.geom_group[geom_id] == expected_group
 
     def test_markers_added_when_requested(self, vision_config):
         fly = Fly(name="vision_fly_markers")
         fly.add_vision(draw_sensor_markers=True)
-        # One marker per eye camera + all hidden body-segment geoms
-        expected = len(vision_config["sensors"]) + len(vision_config["hidden_segments"])
-        assert len(fly.hidden_geoms) == expected
-
-    def test_hidden_segments_present_in_hidden_geoms(self, vision_config):
-        fly = Fly(name="vision_fly_segs")
-        fly.add_vision(draw_sensor_markers=False)
-        hidden_names = {g.name for g in fly.hidden_geoms}
-        assert set(vision_config["hidden_segments"]).issubset(hidden_names)
+        mj_model, _ = fly.compile()
+        for sensor_name in vision_config["sensors"]:
+            marker_name = f"{sensor_name}_marker"
+            marker_id = mj.mj_name2id(mj_model, mj.mjtObj.mjOBJ_GEOM, marker_name)
+            assert marker_id >= 0
+            assert mj_model.geom_group[marker_id] == 1
 
     def test_compiles_after_add_vision(self):
         fly = Fly(name="vision_fly_compile")
@@ -319,23 +331,12 @@ class TestSimulationVisionIDMapping:
         assert ids.dtype == np.int32
         assert (ids >= 0).all()
 
-    def test_hidden_geom_ids_present(self, simulation_with_vision, fly_with_vision, vision_config):
-        ids = simulation_with_vision._intern_hidden_geom_ids_by_fly[fly_with_vision.name]
-        expected = len(vision_config["sensors"]) + len(vision_config["hidden_segments"])
-        assert ids.shape == (expected,)
-        assert ids.dtype == np.int32
-        assert (ids >= 0).all()
-
     def test_fly_without_vision_has_no_ids(
         self, simulation_without_vision, fly_without_vision
     ):
         assert (
             fly_without_vision.name
             not in simulation_without_vision._intern_eye_camera_ids_by_fly
-        )
-        assert (
-            fly_without_vision.name
-            not in simulation_without_vision._intern_hidden_geom_ids_by_fly
         )
 
     def test_get_raw_vision_raises_for_fly_without_vision(
@@ -381,15 +382,12 @@ class TestSimulationGetRawVision:
         assert simulation_with_vision.eye_renderer is not None
 
     def test_hidden_geom_alpha_restored(self, simulation_with_vision, fly_with_vision):
-        """get_raw_vision temporarily zeroes hidden geoms' alpha during rendering;
-        the original values must be restored on return."""
-        hidden_ids = simulation_with_vision._intern_hidden_geom_ids_by_fly[
-            fly_with_vision.name
-        ]
-        before = simulation_with_vision.mj_model.geom_rgba[hidden_ids, 3].copy()
+        """get_raw_vision should keep the scene-option state stable across renders."""
+        before = simulation_with_vision.eye_renderer_scene_option.geomgroup.copy()
         simulation_with_vision.get_raw_vision(fly_with_vision.name)
-        after = simulation_with_vision.mj_model.geom_rgba[hidden_ids, 3]
+        after = simulation_with_vision.eye_renderer_scene_option.geomgroup
         np.testing.assert_array_equal(before, after)
+        assert after[2] == 0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR addresses how self-occlusion is handled during rendering of visual inputs.

**Before:** Before `.update_scene()` is called on the eye renderer, we manually looped over body geoms that should be invisible to the eye cameras and changed the alpha in their `rgba` to 0. We then changed them back to 1 after. This is inherited from FlyGym v1.x.x.

**Now:** The fact that certain geoms should be invisible to the eye cameras is handled by assigning a different geom group to these geoms, and calling the eye renderer's `.update_scene()` with a `MjvOption` configured to ignroe geoms of that group. From MuJoCo docs (https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-geom):
> **group: int, “0”**
> This attribute specifies an integer group to which the geom belongs. The only effect on the physics is at compile time, when body masses and inertias are inferred from geoms selected based on their group; see inertiagrouprange attribute of compiler. At runtime this attribute is used by the visualizer to enable and disable the rendering of entire geom groups. By default, groups 0, 1 and 2 are visible, while all other groups are invisible. The group attribute can also be used as a tag for custom computations.

I didn't do this in v1 because I didn't know this feature existed.

Additionally, I add explicit `.close()` and `.__del__()` methods to `Simulation` and `warp.Simulation` to make management of GL resources more explicit.

@tkclam Could you please
1. Check using your notebook if this is actually working?
2. I changed the unit tests accordingly and they all pass, but could you take a look at them and see if the behavior is still as expected?

In the future we should also add a tutorial on visual input.