### PR TITLE
Add versioned docs via separate flygym-docs repo

### DIFF
--- a/properdocs.yml
+++ b/properdocs.yml
@@ -77,6 +77,8 @@ markdown_extensions:
       permalink: true
 
 extra:
+  version:
+    provider: mike
   analytics:
     provider: google
     property: G-DF8S7T56G7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "mkdocs-literate-nav==0.6.3",
     "mkdocs-section-index==0.3.12",
     "mkdocs-jupyter==0.26.1",
+    "mike>=2.0,<3.0",
     # Mesh simplification
     "trimesh>=4.0,<5.0",
     "shapely>=2.0,<3.0",

--- a/scripts/dev/push_doc_site.sh
+++ b/scripts/dev/push_doc_site.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -e
 
-BUILD_DIR="site"
-BRANCH="gh-pages"
-COMMIT_MSG="Deploy $(date '+%Y-%m-%d %H:%M:%S')"
+DOCS_REMOTE_NAME="flygym-docs"
+DOCS_REMOTE_URL="git@github.com:NeLy-EPFL/flygym-docs.git"
 
 read -p "Have you checked that all tutorial notebooks are properly executed and without errors? (y/n) "
 if [[ $REPLY != "y" ]]; then
@@ -23,14 +22,14 @@ if [[ $REPLY != "y" ]]; then
     exit 1
 fi
 
-if [ -d "$BUILD_DIR" ]; then
-    read -p "The build directory '$BUILD_DIR' already exists. Do you want to remove it and continue? (y/n) "
-    if [[ $REPLY != "y" ]]; then
-        echo "Stopping here."
-        exit 1
-    fi
-    rm -rf "$BUILD_DIR"
-fi
+# Read version from pyproject.toml and let the user confirm or override (e.g.
+# to deploy a dev preview as "2.1.1 (dev)" before the release).
+VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+read -p "Version label [$VERSION]: " VERSION_INPUT
+VERSION="${VERSION_INPUT:-$VERSION}"
+
+read -p "Update 'latest' alias to '$VERSION'? (y/n) "
+UPDATE_LATEST=$REPLY
 
 # Ensure vendor files (MuJoCo-WASM + Three.js) are present, downloading them if
 # needed. Also offer to regenerate the MJCF/STL assets (viewer + game) from the
@@ -50,21 +49,26 @@ if [[ $REGEN_ASSETS == "y" ]]; then
 fi
 uv run python scripts/dev/properdocs_hooks.py --vendor-only
 
-# Build the documentation
-echo "Building documentation..."
-uv run properdocs build
+# Ensure the docs remote exists.
+if ! git remote get-url "$DOCS_REMOTE_NAME" &>/dev/null; then
+    echo "Adding remote '$DOCS_REMOTE_NAME' -> $DOCS_REMOTE_URL"
+    git remote add "$DOCS_REMOTE_NAME" "$DOCS_REMOTE_URL"
+fi
 
-# Push built site to a separate branch to be served by GitHub Pages
-cd "$BUILD_DIR"
-git init
-git checkout --orphan "$BRANCH"
-git add -A
-git commit -m "$COMMIT_MSG"
-git remote add origin $(git -C .. remote get-url origin)
-git push --force origin "$BRANCH"
+# Deploy via mike: builds with properdocs internally (mike calls the 'mkdocs'
+# entry point, which properdocs registers), commits the versioned site into
+# gh-pages on the docs repo, and pushes.
+echo "Deploying '$VERSION' to $DOCS_REMOTE_NAME/gh-pages..."
+if [[ $UPDATE_LATEST == "y" ]]; then
+    uv run mike deploy --push --remote "$DOCS_REMOTE_NAME" \
+        -f properdocs.yml --update-aliases "$VERSION" latest
+else
+    uv run mike deploy --push --remote "$DOCS_REMOTE_NAME" \
+        -f properdocs.yml "$VERSION"
+fi
 
-# Cleanup
-cd ..
-rm -rf "$BUILD_DIR/.git"
+# NOTE: after the very first deploy, run once to make neuromechfly.org/ redirect
+# to the latest version:
+#   uv run mike set-default --push --remote flygym-docs latest
 
-echo "✅ Documentation deployed successfully to branch '$BRANCH'."
+echo "Done. Documentation deployed successfully (version '$VERSION')."

--- a/scripts/dev/push_doc_site.sh
+++ b/scripts/dev/push_doc_site.sh
@@ -61,10 +61,10 @@ fi
 echo "Deploying '$VERSION' to $DOCS_REMOTE_NAME/gh-pages..."
 if [[ $UPDATE_LATEST == "y" ]]; then
     uv run mike deploy --push --remote "$DOCS_REMOTE_NAME" \
-        -f properdocs.yml --update-aliases "$VERSION" latest
+        -F properdocs.yml --update-aliases "$VERSION" latest
 else
     uv run mike deploy --push --remote "$DOCS_REMOTE_NAME" \
-        -f properdocs.yml "$VERSION"
+        -F properdocs.yml "$VERSION"
 fi
 
 # NOTE: after the very first deploy, run once to make neuromechfly.org/ redirect

--- a/scripts/dev/push_doc_site.sh
+++ b/scripts/dev/push_doc_site.sh
@@ -67,8 +67,9 @@ else
         -F properdocs.yml "$VERSION"
 fi
 
-# NOTE: after the very first deploy, run once to make neuromechfly.org/ redirect
-# to the latest version:
-#   uv run mike set-default --push --remote flygym-docs latest
+# NOTE: after the very first deploy, run once to set the root redirect:
+#   uv run mike set-default --push --remote flygym-docs -F properdocs.yml "2.1.1 (dev)"
+# Once a stable release is deployed as 'latest', switch to:
+#   uv run mike set-default --push --remote flygym-docs -F properdocs.yml latest
 
 echo "Done. Documentation deployed successfully (version '$VERSION')."

--- a/scripts/dev/push_doc_site.sh
+++ b/scripts/dev/push_doc_site.sh
@@ -31,6 +31,9 @@ VERSION="${VERSION_INPUT:-$VERSION}"
 read -p "Update 'latest' alias to '$VERSION'? (y/n) "
 UPDATE_LATEST=$REPLY
 
+read -p "Set '$VERSION' as the default version (root redirect)? (y/n) "
+SET_DEFAULT=$REPLY
+
 # Ensure vendor files (MuJoCo-WASM + Three.js) are present, downloading them if
 # needed. Also offer to regenerate the MJCF/STL assets (viewer + game) from the
 # live model.
@@ -67,9 +70,14 @@ else
         -F properdocs.yml "$VERSION"
 fi
 
-# NOTE: after the very first deploy, run once to set the root redirect:
-#   uv run mike set-default --push --remote flygym-docs -F properdocs.yml "2.1.1 (dev)"
-# Once a stable release is deployed as 'latest', switch to:
-#   uv run mike set-default --push --remote flygym-docs -F properdocs.yml latest
+if [[ $SET_DEFAULT == "y" ]]; then
+    DEFAULT_TARGET="$VERSION"
+    if [[ $UPDATE_LATEST == "y" ]]; then
+        DEFAULT_TARGET="latest"
+    fi
+    echo "Setting '$DEFAULT_TARGET' as the default version..."
+    uv run mike set-default --push --remote "$DOCS_REMOTE_NAME" \
+        -F properdocs.yml "$DEFAULT_TARGET"
+fi
 
 echo "Done. Documentation deployed successfully (version '$VERSION')."

--- a/uv.lock
+++ b/uv.lock
@@ -458,33 +458,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
     { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
     { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
-    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
     { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
     { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
     { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
     { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
     { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
     { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
     { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
     { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
     { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
     { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
     { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
     { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
     { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
     { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
     { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
     { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
     { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
     { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
-    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
     { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
     { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
-    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
     { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
     { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
     { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
@@ -706,6 +700,7 @@ dev = [
     { name = "build" },
     { name = "fast-simplification" },
     { name = "mapbox-earcut" },
+    { name = "mike" },
     { name = "mkdocs-gen-files" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-literate-nav" },
@@ -757,6 +752,7 @@ requires-dist = [
     { name = "mapbox-earcut", marker = "extra == 'dev'", specifier = ">=2.0,<3.0" },
     { name = "matplotlib", specifier = ">=3.10,<4.0" },
     { name = "mediapy", specifier = ">=1.2,<3.0" },
+    { name = "mike", marker = "extra == 'dev'", specifier = ">=2.0,<3.0" },
     { name = "mkdocs-gen-files", marker = "extra == 'dev'", specifier = "==0.6.0" },
     { name = "mkdocs-jupyter", marker = "extra == 'dev'", specifier = "==0.26.1" },
     { name = "mkdocs-literate-nav", marker = "extra == 'dev'", specifier = "==0.6.3" },
@@ -1606,6 +1602,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
 ]
 
 [[package]]
@@ -3385,6 +3398,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the plan from #299.

## Changes

- **`pyproject.toml` / `uv.lock`**: add `mike>=2.0` to dev deps (`mike 2.2.0` resolved)
- **`properdocs.yml`**: enable the MkDocs Material version-switcher (`extra.version.provider: mike`)
- **`scripts/dev/push_doc_site.sh`**: replaces the manual git-init/force-push block with `mike deploy`

## New deploy flow

`push_doc_site.sh` now:
1. Reads the version from `pyproject.toml` automatically
2. Prompts to confirm or override the label (e.g. type `2.1.1 (dev)` for a pre-release preview)
3. Prompts whether to update the `latest` alias (answer `n` for dev deploys)
4. Ensures a `flygym-docs` remote exists in the local repo, adding it if not
5. Runs `mike deploy --push --remote flygym-docs -f properdocs.yml ...`

`mike` calls the `mkdocs` entry point internally; `properdocs` registers itself as both `mkdocs` and `properdocs` in the venv, so no compatibility shim is needed.

## One-time setup still required

Before this script can be used:
1. Create `NeLy-EPFL/flygym-docs`, enable GitHub Pages on it
2. Move the `CNAME` (`neuromechfly.org`) file to the new repo
3. After the first successful deploy, run once: `uv run mike set-default --push --remote flygym-docs latest`

## Test plan

- [ ] Create `NeLy-EPFL/flygym-docs` and enable GitHub Pages
- [ ] Run `push_doc_site.sh` for a dev label (`2.1.1 (dev)`), answer `n` to latest alias — verify versioned subdirectory appears on the docs repo
- [ ] Run again for `2.1.1`, answer `y` to latest — verify version switcher shows both entries and `/` redirects to `2.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)