### PR TITLE
Reset mjw_data in place instead of rebuilding GPU structs

### DIFF
--- a/src/flygym/simulation.py
+++ b/src/flygym/simulation.py
@@ -68,7 +68,17 @@ class Simulation:
         self._total_render_time_ns = 0
 
     def reset(self) -> None:
-        """Reset simulation and renderer to the neutral keyframe."""
+        """Reset simulation and renderer to the neutral keyframe.
+
+        !!! warning
+
+            `reset()` does not update derived kinematic quantities (`xpos`,
+            `xquat`, `site_xpos`, ...) -- it only restores state fields
+            (`qpos`, `qvel`, `act`, `ctrl`, `mocap`, `time`). Reading
+            derived quantities right after `reset()`, before calling `step()`,
+            does not reflect the reset state. This is consistent with the behavior of
+            MuJoCo's native `mj_resetData`/`mj_resetDataKeyframe` functions.
+        """
         # Reset physics
         mj.mj_resetDataKeyframe(self.mj_model, self.mj_data, self._neutral_keyframe_id)
 

--- a/src/flygym/warp/simulation.py
+++ b/src/flygym/warp/simulation.py
@@ -21,6 +21,7 @@ from flygym.warp.utils import (
     wp_gather_indexed_cols_2d,
     wp_gather_indexed_rows_vec3f,
     wp_gather_indexed_rows_quatf,
+    reset_data_keyframe,
 )
 
 
@@ -68,12 +69,21 @@ class GPUSimulation(Simulation):
 
     @override
     def reset(self) -> None:
-        """Reset all parallel worlds to the neutral keyframe."""
+        """Reset all parallel worlds to the neutral keyframe.
+
+        !!! warning
+
+            `reset()` does not update derived kinematic quantities (`xpos`,
+            `xquat`, `site_xpos`, ...); it only restores state fields
+            (`qpos`, `qvel`, `act`, `ctrl`, `mocap`, `time`). Reading
+            derived quantities right after `reset()`, before calling `step()`,
+            returns stale values from before the reset. This is consistent with the
+            behavior of MuJoCo Warp's native `reset_data()` function.
+        """
         super().reset()
-        # The superclass call resets CPU-side MuJoCo structs to the neutral keyframe,
-        # so we need to recreate GPU-side structs to reflect that reset.
-        self.mjw_model, self.mjw_data = self._mj_structs_to_mjw_structs()
-        # ... don't call mjw.reset_data() here! That loses the keyframe reset.
+        reset_data_keyframe(
+            self.mj_model, self.mjw_model, self.mjw_data, self._neutral_keyframe_id
+        )
 
     @override
     def get_joint_angles(

--- a/src/flygym/warp/utils.py
+++ b/src/flygym/warp/utils.py
@@ -1,6 +1,8 @@
-import warp as wp
+from typing import Optional
 
-from mujoco_warp._src.types import RenderContext
+import warp as wp
+import mujoco as mj
+import mujoco_warp as mjw
 
 
 @wp.kernel
@@ -153,7 +155,7 @@ def unpack_rgb_kernel_selected_worlds_and_cameras(
 
 
 def get_rgb_selected_worlds_and_cameras(
-    rc: RenderContext,
+    rc: mjw.RenderContext,
     worldids: wp.array(dtype=int),  # type: ignore
     camids: wp.array(dtype=int),  # type: ignore
     rgb_out: wp.array4d(dtype=wp.vec3),  # type: ignore
@@ -203,3 +205,194 @@ def check_gpu():
             "You can specify which GPU to use by setting the 'CUDA_VISIBLE_DEVICES' "
             "environment variable."
         )
+
+
+def reset_data_keyframe(
+    mj_model: mj.MjModel,
+    mjw_model: mjw.Model,
+    mjw_data: mjw.Data,
+    key: int,
+    reset: Optional[wp.array] = None,
+):
+    """In-place equivalent of ``mj_resetDataKeyframe`` for a batched MJWarp ``Data``.
+
+    This functionality is not provided natively by MuJoCo Warp, so this is a custom
+    implementation. Note: this function differs from other Warp utils in that it
+    requires both the `mujoco.MjModel` object and the `mujoco_warp.types.Model` object.
+    This is because `key_{qpos,qvel,act,mpos,mquat,ctrl}` are not tracked by the
+    GPU-side model.
+
+    Args:
+        mj_model: CPU-side MuJoCo model holding the keyframe to reset to.
+        mjw_model: GPU-side MuJoCo-Warp model instance.
+        mjw_data: GPU-side MuJoCo-Warp data instance.
+        key: Index of the keyframe (in `mj_model`) to reset to.
+        reset: Optional per-world boolean mask, shape `(mjw_data.nworld,)`.
+    """
+    mjw.reset_data(mjw_model, mjw_data, reset)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def reset_time(
+        # From MjModel:
+        target_time: float,
+        # In:
+        reset_in: wp.array[bool],
+        # Data out:
+        time_out: wp.array[float],
+    ):
+        worldid = wp.tid()
+
+        if wp.static(reset is not None):
+            if not reset_in[worldid]:
+                return
+
+        time_out[worldid] = target_time
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def reset_qpos(
+        # From MjModel:
+        target_qpos: wp.array[float],
+        # In:
+        reset_in: wp.array[bool],
+        # Data out:
+        qpos_out: wp.array2d[float],
+    ):
+        worldid, qid = wp.tid()
+
+        if wp.static(reset is not None):
+            if not reset_in[worldid]:
+                return
+
+        qpos_out[worldid, qid] = target_qpos[qid]
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def reset_qvel(
+        # From MjModel:
+        target_qvel: wp.array[float],
+        # In:
+        reset_in: wp.array[bool],
+        # Data out:
+        qvel_out: wp.array2d[float],
+    ):
+        worldid, vid = wp.tid()
+
+        if wp.static(reset is not None):
+            if not reset_in[worldid]:
+                return
+
+        qvel_out[worldid, vid] = target_qvel[vid]
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def reset_activation(
+        # From MjModel:
+        target_act: wp.array[float],
+        # In:
+        reset_in: wp.array[bool],
+        # Data out:
+        act_out: wp.array2d[float],
+    ):
+        worldid, aid = wp.tid()
+
+        if wp.static(reset is not None):
+            if not reset_in[worldid]:
+                return
+
+        act_out[worldid, aid] = target_act[aid]
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def reset_mocap(
+        # From MjModel:
+        target_mpos: wp.array[wp.vec3],
+        target_mquat: wp.array[wp.quat],
+        # From mjwarp Model:
+        body_mocapid: wp.array[int],
+        # In:
+        reset_in: wp.array[bool],
+        # Data out:
+        mocap_pos_out: wp.array2d[wp.vec3],
+        mocap_quat_out: wp.array2d[wp.quat],
+    ):
+        worldid, bodyid = wp.tid()
+
+        if wp.static(reset is not None):
+            if not reset_in[worldid]:
+                return
+
+        mocapid = body_mocapid[bodyid]
+
+        if mocapid >= 0:
+            mocap_pos_out[worldid, mocapid] = target_mpos[mocapid]
+            mocap_quat_out[worldid, mocapid] = target_mquat[mocapid]
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def reset_control(
+        # From MjModel:
+        target_ctrl: wp.array[float],
+        # In:
+        reset_in: wp.array[bool],
+        # Data out:
+        ctrl_out: wp.array2d[float],
+    ):
+        worldid, cid = wp.tid()
+
+        if wp.static(reset is not None):
+            if not reset_in[worldid]:
+                return
+
+        ctrl_out[worldid, cid] = target_ctrl[cid]
+
+    reset_input = reset or wp.ones(mjw_data.nworld, dtype=bool)
+
+    target_time = mj_model.key_time[key]
+    wp.launch(
+        reset_time,
+        dim=mjw_data.nworld,
+        inputs=[target_time, reset_input],
+        outputs=[mjw_data.time],
+    )
+
+    target_qpos = wp.array(mj_model.key_qpos[key], dtype=float)
+    wp.launch(
+        reset_qpos,
+        dim=(mjw_data.nworld, mjw_model.nq),
+        inputs=[target_qpos, reset_input],
+        outputs=[mjw_data.qpos],
+    )
+
+    target_qvel = wp.array(mj_model.key_qvel[key], dtype=float)
+    wp.launch(
+        reset_qvel,
+        dim=(mjw_data.nworld, mjw_model.nv),
+        inputs=[target_qvel, reset_input],
+        outputs=[mjw_data.qvel],
+    )
+
+    target_act = wp.array(mj_model.key_act[key], dtype=float)
+    wp.launch(
+        reset_activation,
+        dim=(mjw_data.nworld, mjw_model.na),
+        inputs=[target_act, reset_input],
+        outputs=[mjw_data.act],
+    )
+
+    target_mpos = wp.array(mj_model.key_mpos[key], dtype=wp.vec3)
+    target_mquat = wp.array(mj_model.key_mquat[key], dtype=wp.quat)
+    wp.launch(
+        reset_mocap,
+        dim=(mjw_data.nworld, mjw_model.nbody),
+        inputs=[
+            target_mpos,
+            target_mquat,
+            mjw_model.body_mocapid,
+            reset_input,
+        ],
+        outputs=[mjw_data.mocap_pos, mjw_data.mocap_quat],
+    )
+
+    target_ctrl = wp.array(mj_model.key_ctrl[key], dtype=float)
+    wp.launch(
+        reset_control,
+        dim=(mjw_data.nworld, mjw_model.nu),
+        inputs=[target_ctrl, reset_input],
+        outputs=[mjw_data.ctrl],
+    )

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -153,6 +153,14 @@ class TestGetBodyPositions:
         pos = simulation.get_body_positions(fly_with_adhesion.name)
         assert pos.shape[0] == len(ALL_SEGMENT_NAMES)
 
+    def test_positions_correct_after_reset_and_step(
+        self, simulation, fly_with_adhesion
+    ):
+        simulation.reset()
+        simulation.step()
+        pos = simulation.get_body_positions(fly_with_adhesion.name)
+        assert not np.allclose(pos, 0.0)
+
 
 # ==============================================================================
 # get_body_rotations

--- a/tests/warp/test_simulation.py
+++ b/tests/warp/test_simulation.py
@@ -3,6 +3,7 @@
 import warnings
 import pytest
 import numpy as np
+import mujoco as mj
 
 # These tests require the optional warp (GPU) extra; tag them so they can be
 # excluded with ``-m "not warp"``, and skip the whole module if warp is absent.
@@ -165,6 +166,79 @@ class TestReset:
         sim.reset()
         assert sim._total_physics_time_ns == 0
 
+    def test_reset_does_not_reallocate_gpu_structs(self, gpu_bundle):
+        """reset() should reset mjw_data in place, not rebuild it from scratch."""
+        sim, fly, cam = gpu_bundle
+        mjw_model_before = sim.mjw_model
+        mjw_data_before = sim.mjw_data
+        sim.step()
+        sim.reset()
+        assert sim.mjw_model is mjw_model_before
+        assert sim.mjw_data is mjw_data_before
+
+    def test_reset_restores_joint_angles_without_a_subsequent_step(self, gpu_bundle):
+        """State fields (qpos, ...) are restored by reset() itself, since
+        reset_data_keyframe writes them directly -- no step() needed."""
+        sim, fly, cam = gpu_bundle
+        sim.reset()
+        baseline = sim.get_joint_angles(fly.name).numpy().copy()
+
+        # Drive the position actuators away from the neutral pose so stepping
+        # actually moves the joints (they'd otherwise be held at neutral).
+        displaced = baseline + 0.3
+        sim.set_actuator_inputs(fly.name, ActuatorType.POSITION, displaced)
+        for _ in range(20):
+            sim.step()
+        moved = sim.get_joint_angles(fly.name).numpy()
+        assert not np.allclose(moved, baseline, atol=1e-3)
+
+        sim.reset()
+        restored = sim.get_joint_angles(fly.name).numpy()
+        np.testing.assert_allclose(restored, baseline, atol=1e-5)
+
+    def test_body_positions_are_stale_immediately_after_reset(self, gpu_bundle):
+        """Mirrors mj_resetDataKeyframe: reset() only restores state fields (qpos,
+        qvel, act, ctrl, mocap, time). Derived kinematic quantities like xpos are
+        not recomputed, so immediately after reset() -- before any step() -- they
+        still hold whatever was there before the reset, not the neutral pose.
+        """
+        sim, fly, cam = gpu_bundle
+        sim.reset()
+        sim.step()
+        after_step = sim.get_body_positions(fly.name).numpy().copy()
+
+        sim.reset()
+        still_stale = sim.get_body_positions(fly.name).numpy()
+        np.testing.assert_allclose(still_stale, after_step)
+
+    def test_body_positions_correct_after_reset_and_step(self, gpu_bundle):
+        """Once step() runs (which begins with a forward pass), derived kinematic
+        quantities catch up to the reset state."""
+        sim, fly, cam = gpu_bundle
+        for _ in range(20):
+            sim.step()
+        sim.reset()
+        sim.step()
+        gpu_positions = sim.get_body_positions(fly.name).numpy()
+
+        mj.mj_resetDataKeyframe(sim.mj_model, sim.mj_data, sim._neutral_keyframe_id)
+        mj.mj_step(sim.mj_model, sim.mj_data)
+        internal_ids = sim._internal_bodyids_by_fly[fly.name]
+        cpu_positions = sim.mj_data.xpos[internal_ids, :]
+
+        for world_positions in gpu_positions:
+            np.testing.assert_allclose(world_positions, cpu_positions, atol=1e-4)
+
+    def test_reset_restores_qpos_to_neutral_keyframe(self, gpu_bundle):
+        sim, fly, cam = gpu_bundle
+        for _ in range(5):
+            sim.step()
+        sim.reset()
+        expected = np.tile(
+            sim.mj_model.key_qpos[sim._neutral_keyframe_id], (sim.n_worlds, 1)
+        )
+        np.testing.assert_allclose(sim.mjw_data.qpos.numpy(), expected, atol=1e-5)
+
 
 # ==============================================================================
 # State queries
@@ -250,8 +324,15 @@ class TestSiteStateQueries:
         sim.reset()
         sim.step()
         gpu_site_xpos = sim.get_site_positions(fly.name).numpy()[0]
+
+        # sim.reset() does not forward-compute derived quantities on the CPU side
+        # either (mirroring mj_resetDataKeyframe), so explicitly reset + step the CPU
+        # reference here rather than relying on sim.mj_data being pre-populated.
+        mj.mj_resetDataKeyframe(sim.mj_model, sim.mj_data, sim._neutral_keyframe_id)
+        mj.mj_step(sim.mj_model, sim.mj_data)
         cpu_site_xpos = sim.mj_data.site_xpos[sim._internal_siteids_by_fly[fly.name], :]
-        np.testing.assert_allclose(gpu_site_xpos, cpu_site_xpos, atol=1e-6)
+
+        np.testing.assert_allclose(gpu_site_xpos, cpu_site_xpos, atol=1e-4)
 
 
 # ==============================================================================

--- a/tests/warp/test_utils.py
+++ b/tests/warp/test_utils.py
@@ -7,6 +7,8 @@ import numpy as np
 # excluded with ``-m "not warp"``, and skip the whole module if warp is absent.
 pytestmark = pytest.mark.warp
 wp = pytest.importorskip("warp")
+mjw = pytest.importorskip("mujoco_warp")
+mj = pytest.importorskip("mujoco")
 
 
 # ==============================================================================
@@ -389,3 +391,135 @@ class TestGetRgbSelectedWorldsAndCamerasValidation:
 
         with pytest.raises(ValueError, match="camids"):
             get_rgb_selected_worlds_and_cameras(rc, worldids, camids, rgb_out)
+
+
+# ==============================================================================
+# reset_data_keyframe
+# ==============================================================================
+
+# A free joint (nq=7, nv=6) plus a hinge joint (nq=1, nv=1) gives a model
+# where nq != nv, which is the case that exposed the qpos/qvel kernel bug.
+# One actuator (with activation state) exercises act/ctrl, and one mocap
+# body exercises mocap_pos/mocap_quat.
+_RESET_KEYFRAME_XML = """
+<mujoco>
+  <worldbody>
+    <body name="free_body" pos="0 0 1">
+      <freejoint name="fj"/>
+      <geom type="sphere" size="0.1"/>
+      <body name="child" pos="0.2 0 0">
+        <joint name="hinge1" type="hinge" axis="0 0 1"/>
+        <geom type="sphere" size="0.05"/>
+      </body>
+    </body>
+    <body name="mocap_body" mocap="true" pos="1 2 3" quat="1 0 0 0">
+      <geom type="sphere" size="0.05"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <general joint="hinge1" dyntype="filter" dynprm="0.5" gaintype="fixed" gainprm="1"/>
+  </actuator>
+  <keyframe>
+    <key name="k0" time="0.5"
+         qpos="0.1 0.2 0.3 1 0 0 0 0.5"
+         qvel="0.01 0.02 0.03 0.04 0.05 0.06 0.7"
+         act="0.33"
+         ctrl="0.44"
+         mpos="9 8 7" mquat="0 1 0 0"/>
+  </keyframe>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def mj_and_mjw():
+    mj_model = mj.MjModel.from_xml_string(_RESET_KEYFRAME_XML)
+    mj_data = mj.MjData(mj_model)
+    # sanity-check the model actually has nq != nv, which is what this test
+    # suite cares about exercising.
+    assert mj_model.nq != mj_model.nv
+    mjw_model = mjw.put_model(mj_model)
+    mjw_data = mjw.put_data(mj_model, mj_data, nworld=3)
+    return mj_model, mjw_model, mjw_data
+
+
+class TestResetDataKeyframe:
+    def test_resets_all_worlds_to_keyframe_values(self, mj_and_mjw):
+        from flygym.warp.utils import reset_data_keyframe
+
+        mj_model, mjw_model, mjw_data = mj_and_mjw
+
+        # Perturb data away from both the keyframe and the model defaults so
+        # a no-op kernel launch would be caught by the assertions below.
+        mjw_data.qpos.fill_(-1.0)
+        mjw_data.qvel.fill_(-1.0)
+        mjw_data.time.fill_(-1.0)
+
+        reset_data_keyframe(mj_model, mjw_model, mjw_data, key=0)
+
+        n = mjw_data.nworld
+        np.testing.assert_allclose(
+            mjw_data.qpos.numpy(), np.tile(mj_model.key_qpos[0], (n, 1))
+        )
+        np.testing.assert_allclose(
+            mjw_data.qvel.numpy(), np.tile(mj_model.key_qvel[0], (n, 1))
+        )
+        np.testing.assert_allclose(
+            mjw_data.act.numpy(), np.tile(mj_model.key_act[0], (n, 1))
+        )
+        np.testing.assert_allclose(
+            mjw_data.ctrl.numpy(), np.tile(mj_model.key_ctrl[0], (n, 1))
+        )
+        np.testing.assert_allclose(
+            mjw_data.mocap_pos.numpy()[:, 0, :],
+            np.tile(mj_model.key_mpos[0], (n, 1)),
+        )
+        np.testing.assert_allclose(
+            mjw_data.mocap_quat.numpy()[:, 0, :],
+            np.tile(mj_model.key_mquat[0], (n, 1)),
+        )
+        np.testing.assert_allclose(mjw_data.time.numpy(), [0.5] * n)
+
+    def test_qvel_write_does_not_overrun_into_neighboring_world(self, mj_and_mjw):
+        """Regression test: qpos has nq=8 columns but qvel only has nv=7.
+
+        A kernel that loops over nq columns and writes both qpos_out and
+        qvel_out at the same column index writes one element past the end
+        of each world's qvel row. Because qvel is stored as a flat
+        (nworld, nv) buffer, that out-of-bounds column aliases column 0 of
+        the next world's row. qpos and qvel are reset by separate kernels,
+        each launched with its own dimension (nq vs. nv).
+        """
+        from flygym.warp.utils import reset_data_keyframe
+
+        mj_model, mjw_model, mjw_data = mj_and_mjw
+
+        mjw_data.qvel.fill_(-1.0)
+        reset_input = wp.array([True, False, True], dtype=bool)
+        reset_data_keyframe(mj_model, mjw_model, mjw_data, key=0, reset=reset_input)
+
+        qvel = mjw_data.qvel.numpy()
+        np.testing.assert_allclose(qvel[0], mj_model.key_qvel[0])
+        np.testing.assert_allclose(qvel[2], mj_model.key_qvel[0])
+        # World 1 was excluded from the reset and must be untouched.
+        np.testing.assert_allclose(qvel[1], np.full(mj_model.nv, -1.0))
+
+    def test_partial_reset_leaves_unselected_worlds_untouched(self, mj_and_mjw):
+        from flygym.warp.utils import reset_data_keyframe
+
+        mj_model, mjw_model, mjw_data = mj_and_mjw
+
+        mjw_data.qpos.fill_(0.0)
+        mjw_data.time.fill_(99.0)
+        reset_input = wp.array([True, False, True], dtype=bool)
+
+        reset_data_keyframe(mj_model, mjw_model, mjw_data, key=0, reset=reset_input)
+
+        qpos = mjw_data.qpos.numpy()
+        time = mjw_data.time.numpy()
+        np.testing.assert_allclose(qpos[0], mj_model.key_qpos[0])
+        np.testing.assert_allclose(qpos[2], mj_model.key_qpos[0])
+        np.testing.assert_allclose(qpos[1], np.zeros(mj_model.nq))
+        assert time[1] == pytest.approx(99.0)
+        assert time[0] == pytest.approx(0.5)
+        assert time[2] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- `GPUSimulation.reset()` used to call `mjw.put_model`/`mjw.put_data` on every reset, reallocating the GPU-side `Model`/`Data` from scratch. Add `reset_data_keyframe()` (a GPU analog of `mj_resetDataKeyframe`, built on `mujoco_warp.reset_data` plus custom kernels for `qpos`/`qvel`/`act`/`ctrl`/`mocap`/`time`) and use it to reset `mjw_data` in place instead.
- Fixed two bugs in the process: an argument-order mismatch in the mocap-reset kernel launch (crashed immediately), and an out-of-bounds write when `nq != nv` (e.g. free/ball joints) from sharing one kernel/launch dimension for both `qpos` and `qvel`.
- Neither `mj_resetDataKeyframe` (CPU) nor `mujoco_warp.reset_data` (GPU) recompute derived kinematic quantities (`xpos`, `xquat`, `site_xpos`, ...) — only state fields (`qpos`, `qvel`, `act`, `ctrl`, `mocap`, `time`). Documented this contract with `!!! warning` admonitions on both `Simulation.reset()` and `GPUSimulation.reset()`, and added tests that assert the actual behavior (CPU zeroes these fields via `_resetData`; GPU/mujoco_warp leaves them stale) instead of only checking shapes.

## Test plan
- [x] `pytest tests/core/test_simulation.py tests/warp/ -q` — 123 passed
- [x] Manually reproduced and confirmed the fix for the mocap-kernel argument-order crash and the qpos/qvel out-of-bounds write (free-joint model, `nq != nv`) before landing the fix